### PR TITLE
docs: remove alphabetical order mention for translated content

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -20,7 +20,7 @@ Eine Liste öffentlicher Quellcodes von Schweizer Behörden.
 | Schweizer Geoportal                       | [Link](https://github.com/geoadmin)             |
 | Eidgenössisches Institut für Metrologie   | [Link](https://github.com/metas-ch)             |
 
-## Kantonale Dienste (alphabetische Reihenfolge)
+## Kantonale Dienste
 
 | Kanton                 | Link                                                            |
 | ---------------------- | --------------------------------------------------------------- |

--- a/README.fr.md
+++ b/README.fr.md
@@ -20,7 +20,7 @@ Une liste de codes sources publics des autorités suisses.
 | Géoportail Suisse                   | [Link](https://github.com/geoadmin)             |
 | Institut fédéral de métrologie      | [Link](https://github.com/metas-ch)             |
 
-## Services Cantonaux (Ordre Alphabétique)
+## Services Cantonaux
 
 | Canton                       | Link                                                        |
 | ---------------------------- | ----------------------------------------------------------- |

--- a/README.it.md
+++ b/README.it.md
@@ -20,7 +20,7 @@ Un elenco di codici sorgente pubblici delle autorità svizzere.
 | Geoportale svizzero                    | [Link](https://github.com/geoadmin)             |
 | Istituto federale di metrologia        | [Link](https://github.com/metas-ch)             |
 
-## Servizi cantonali (ordine alfabetico)
+## Servizi cantonali
 
 | Cantone            | Link                                                            |
 | ------------------ | --------------------------------------------------------------- |

--- a/README.rm.md
+++ b/README.rm.md
@@ -20,7 +20,7 @@ Ina glista dals codes da funtauna publics dad autoritads svizras.
 | Geoportal svizzer                       | [Link](https://github.com/geoadmin)             |
 | Institut federal da metrologia          | [Link](https://github.com/metas-ch)             |
 
-## Servetschs chantunals (incumbensa alfabetica)
+## Servetschs chantunals
 
 | Chantun           | Link                                                            |
 | ----------------- | --------------------------------------------------------------- |


### PR DESCRIPTION
Machine translated files maintain the order defined in English, they aren't sorted alphabetically for all languages.
