### PR TITLE
Stabilize the generator + add tooling, tests, CI, and project plan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Format check (ruff)
+        run: ruff format --check .
+
+      - name: Test (pytest)
+        run: pytest
+
+      - name: Verify data/ is in sync with README.md
+        run: |
+          python scripts/create_yamls.py
+          if [ -n "$(git status --porcelain data/)" ]; then
+            echo "::error::data/ is out of sync with README.md. Run 'python scripts/create_yamls.py' and commit the result."
+            git status --porcelain data/
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,9 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# Ruff
+.ruff_cache/
+
 # Translations
 *.mo
 *.pot

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,273 @@
+# Design Proposal: From an awesome-list to a Swiss public-sector OSS inventory
+
+**Status:** Draft for discussion
+**Scope:** Evolves `awesome-codeswissgov` from a hand-curated link list into the
+canonical, machine-readable inventory of Swiss public-sector open source.
+**Supersedes:** `issues.md` (its content is folded into Phase 0 and the appendix).
+
+---
+
+## 1. Context & motivation
+
+`awesome-codeswissgov` is currently an *awesome-list*: `README.md` holds two
+hand-maintained markdown tables (federal + cantonal GitHub orgs), and
+`scripts/create_yamls.py` derives one `data/*.yaml` file per row for machine
+consumption. It is curated under the `ospo-ch` org and synced from the federal
+`github.com/swiss/index`.
+
+What makes this strategically important is its legal backdrop. Switzerland's
+**EMBAG** law (in force since 2024) makes *"public money → public code"* the
+**default** for federal authorities: software developed by or for them is
+expected to be released openly unless there's a specific reason not to. That
+turns a nice-to-have directory into the visible edge of a **discovery,
+inventory, and compliance** problem that an OSPO must run continuously.
+
+**Today we track ~50 orgs. An OSPO needs to know the repositories inside them —
+their licenses, activity, and health — and which authorities publish nothing at
+all.** That is the gap this proposal closes.
+
+---
+
+## 2. North star
+
+> The canonical, machine-readable inventory of Swiss public-sector open source:
+> **who** publishes, **what** they publish, under **which license**, and **how
+> healthy** it is — consumable as data, with the README as one rendered view.
+
+Success looks like being able to answer, automatically and on a schedule:
+
+- Which authorities (federal / cantonal) publish *anything*?
+- Which repositories have **no license** or are **archived/stale**?
+- What is the language / license / activity mix across the public sector?
+- Where does Swiss gov code **reuse** other Swiss gov code?
+
+---
+
+## 3. Proposed architecture
+
+Flip the data flow from **"human edits README → script derives YAML"** to
+**"harvester produces data → README is a generated view."**
+
+```
+            ┌─────────────────────────┐
+ sources ──▶│  Discovery + Harvester  │──▶  data/ (structured inventory)
+ (orgs,     │  (GitHub API,            │          │
+  registries│   publiccode.yml, code.json)        ├──▶ README.md  (generated view)
+  domains)  └─────────────────────────┘          ├──▶ inventory.json (data product / API)
+                                                  └──▶ reports (license %, stale, coverage)
+```
+
+Key consequences:
+
+- **The sync/orphan class of bugs disappears.** When `data/` is the source and
+  the README is regenerated, there is no manual two-way sync to drift, and a
+  self-cleaning generator removes stale records by construction.
+- **`data/` becomes the product**, not a byproduct. The README, a JSON feed, and
+  reports are all *views* of the same dataset.
+- **Curation stays human where it matters** (verifying that an org is genuinely
+  official) but enrichment (license, activity, language) is automated.
+
+### 3.1 Adopt a standard metadata schema
+
+Replace the ad-hoc `{name, link_title, link_url}` shape with a model aligned to
+**`publiccode.yml`** (Foundation for Public Code; harvested by Italy's
+*Developers Italia*) and interoperable with the US **`code.json`** (code.gov).
+
+Proposed per-record fields (org- and repo-level):
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `name` | curated | display name |
+| `authority` | curated | e.g. `federal`, `canton:ZH` |
+| `official` | curated | verified-official flag / provenance |
+| `url` | curated/harvested | GitHub org or repo URL |
+| `license` | harvested | SPDX id; **empty = compliance flag** |
+| `language` | harvested | primary language |
+| `topics` | harvested | repo topics |
+| `last_activity` | harvested | last pushed/commit date |
+| `archived` | harvested | bool |
+| `has_publiccode_yml` | harvested | self-description present |
+
+Aligning with `publiccode.yml` lets us **ingest from and be ingested by** the EU
+ecosystem for free, and lets us nudge agencies to drop a `publiccode.yml` in
+their repos so they become self-describing.
+
+---
+
+## 4. Discovery strategy
+
+Discovery is the hard, never-finished part. Vectors, roughly by yield:
+
+1. **Org expansion** — for each known org, list members and their *other* org
+   memberships; gov developers cluster.
+2. **Heuristic search** on GitHub: `kanton-*`, `stadt-*`, `*-admin-ch`,
+   canton names, "Amt für…", official domains in profiles.
+3. **Cross-reference sibling registries** — `swiss/index`, France's
+   `code.gouv.fr` (API), Germany's **openCoDE**, Developers Italia, EU
+   **Joinup**, US **code.gov**. Reuse their work to surface the *GitHub* orgs
+   they list.
+4. **Domain harvesting** — probe `*.admin.ch` / `*.<canton>.ch` for a published
+   `code.json` / `publiccode.yml` at a well-known path (the code.gov model).
+5. **Package registries** — gov orgs on npm/PyPI/Maven/Docker Hub (linking back
+   to GitHub source).
+6. **Procurement signals** — SIMAP/tender data referencing repos.
+7. **Crowdsourcing** — a one-click "suggest an org/repo" issue template.
+
+> **Scope note:** discovery surfaces **GitHub** orgs/repos only. Sources that
+> point to GitLab / openCoDE / Bitbucket are noted but not inventoried — see the
+> accepted-limitation entry under Challenges.
+
+---
+
+## 5. Roadmap
+
+### Phase 0 — Stabilize the current tool (the `issues.md` backlog)
+
+Quick, self-contained fixes that also de-risk the bigger refactor. Detailed in
+the [appendix](#appendix-phase-0-issue-detail).
+
+- Make the generator **self-cleaning** (remove orphaned YAML) — **bug**
+- Fix the **"Graubüden" → "Graubünden"** typo — **bug**
+- Fix **invalid regex escape sequences** (raw strings) — **bug**
+- Add **CI** to enforce README ↔ `data/` sync — **DX**
+- Render the **14 no-org cantons** as plain text, not broken `[GitHub Org]` — **bug**
+- Harden the **parser** (regex links, strip fields, path-independent, clear
+  errors) — **DX**
+- Add a **Contributing** section and **unit tests** — **docs / DX**
+
+### Phase 1 — Enrichment harvester (the headline feature)
+
+- GitHub API harvester: expand each org into repos with license, language,
+  activity, archived status, `publiccode.yml`/`SECURITY.md` presence.
+- Scheduled GitHub Action (cron) writes enriched `data/`.
+- **Regenerate the README from `data/`** (architecture flip).
+
+### Phase 2 — Schema & ecosystem alignment
+
+- Migrate to the `publiccode.yml`-aligned model (§3.1).
+- Publish `inventory.json` as a data product / lightweight API.
+- Ingest from `swiss/index` and at least one sibling registry to seed coverage.
+
+### Phase 3 — Discovery automation & reporting
+
+- Implement discovery vectors §4 (org expansion, heuristic search, domain probe).
+- Reports: license coverage %, stale/archived counts, **authority coverage**
+  ("who publishes nothing"), and a simple **EMBAG visibility** view.
+
+### Phase 4 — Governance & community
+
+- Verification/provenance model for "official" orgs (badge).
+- Contribution governance, suggestion templates, link-rot detection bot.
+
+---
+
+## 6. Challenges & risks
+
+- **"Has a GitHub org" ≠ "EMBAG-compliant."** The list must not imply compliance
+  it can't verify.
+- **Official vs. unofficial / personal** projects — needs a provenance model or
+  it publishes noise.
+- **Coverage limitation (accepted): GitHub only.** GitLab (incl. self-hosted /
+  openCoDE), Bitbucket and other forges are out of scope; authorities that
+  publish only off GitHub won't appear. Coverage means "present on GitHub", not
+  "publishes open source" — state this wherever numbers are reported so the
+  under-count isn't read as "publishes nothing".
+- **Org churn** — renames, archives, deletions → link rot. Automation must
+  detect 404s.
+- **Multilingual reality.** CH has 4 national languages; i18n was just dropped
+  (commit `67e33e8`). An *inventory* can stay structured/English, but a
+  *citizen-facing catalog* may need DE/FR/IT/RM — a conscious product decision,
+  not a silent default.
+- **Security/privacy footgun.** Surfacing repos can amplify accidental
+  secret/PII leaks; consider basic hygiene checks rather than pure advertising.
+- **Sustainability.** Manual curation doesn't scale past a few dozen orgs;
+  without automation the list decays.
+- **Positioning vs. `swiss/index`.** Resolved as a superset that adds cantonal
+  breadth + enrichment and ingests `swiss/index` as the federal source — not a
+  mirror, to avoid duplicate work and user confusion.
+- **API rate limits & auth.** Harvesting at scale needs a token and caching;
+  design for incremental updates.
+
+---
+
+## 7. Decisions (resolved — see `SPEC.md` for detail)
+
+1. **Architecture flip** — ✅ `data/` is the source of truth; README is a
+   generated view.
+2. **Schema** — ✅ adopt a `publiccode.yml`-compatible model shape during the
+   flip (Epic 1); defer full import/export to Epic 3.
+3. **Positioning vs. `swiss/index`** — ✅ superset + enrichment; ingest
+   `swiss/index` as the federal source rather than mirroring it.
+4. **Scope** — ✅ federal + cantonal only; municipal out of scope (submission/
+   allowlist only, if ever).
+5. **i18n** — ✅ English/structured inventory; any multilingual view is generated
+   off the same `data/`, not a fork.
+6. **GitHub auth** — ✅ read-only fine-grained PAT in an Actions secret; GraphQL.
+7. **Repo data volume** — ✅ org-level YAML committed; repo data lives only in the
+   generated `inventory.json` (no per-repo files).
+
+---
+
+## Appendix: Phase 0 issue detail
+
+Audit findings from the Senior Staff review. README.md is currently the source
+of truth; `scripts/create_yamls.py` generates the per-entry `data/*.yaml` files.
+
+Status legend: 🐞 bug · 🛠️ DX/maintainability · 📄 docs
+
+### High priority
+
+**1. 🐞 Generator leaves orphaned YAML files behind.**
+`create_yamls.py` writes files but never deletes them, so renamed/removed README
+entries leave stale files in `data/` forever. **3 orphans** are currently
+committed (58 README entries, 61 files):
+`data/admin_swiss_federal_office_of_energy.yaml`,
+`data/admin_swiss_federal_chancellery.yaml`,
+`data/admin_swiss_federal_archives.yaml`.
+*Fix:* track files written during a run and remove any `data/*.yaml` not in that
+set. (Dissolved entirely by the Phase 1 architecture flip.)
+
+**2. 🐞 Typo in cantonal data: "Graubüden".**
+`README.md:54` reads `Graubüden` — should be `Graubünden`; the typo propagates
+into the filename (`graubuden_github_org.yaml`) and YAML.
+*Fix:* correct the spelling and regenerate.
+
+**3. 🐞 Invalid escape sequences in regexes.**
+`create_yamls.py:87-88` use non-raw strings `"[^\w\s]"` and `"[-\s]+"`
+(`DeprecationWarning` on 3.11, `SyntaxWarning` on 3.12+, future hard error).
+*Fix:* raw strings (`r"[^\w\s]"`, `r"[-\s]+"`).
+
+### Medium priority
+
+**4. 🛠️ Nothing keeps README and `data/` in sync.**
+YAML is generated manually; the two drift silently and no CI catches it.
+*Fix:* GitHub Actions workflow that installs deps, runs the generator, and fails
+with `git diff --exit-code data/` on drift.
+
+**5. 🐞 Broken markdown for cantons with no org.**
+14 cantons use `[GitHub Org]` with no URL (Appenzell Ausserrhoden, Fribourg,
+Glarus, Graubünden, Jura, Lucerne, Nidwalden, Obwalden, Schaffhausen, Schwyz,
+Ticino, Uri, Valais, Zug); with no target they render as literal `[GitHub Org]`.
+*Decision (agreed):* keep them as intentional placeholders but render plain text
+(e.g. `— none known yet`); the generator maps link-less cells to empty
+`link_title`/`link_url` and names the file after the canton only.
+
+**6. 🛠️ Fragile parser.**
+Relies on exact marker strings (`list.index()` raises uncaught `ValueError` if a
+marker moves); naive `|`/`]` splitting; `name` not stripped; must run from repo
+root (hard-coded `./README.md`).
+*Fix:* regex link parsing, strip fields, resolve paths from `__file__`, clear
+error when a marker is missing.
+
+### Low priority
+
+**7. 📄 No contributor guidance.** No section explains the README → `data/`
+workflow, running `python3 scripts/create_yamls.py`, or the YAML schema.
+*Fix:* add a short "Contributing" section.
+
+**8. 🛠️ No tests.** Add unit tests for `parse_row` and `convert_to_filename`
+(link, no-link, accented names).
+
+**9. 🛠️ Tooling hygiene (optional).** No linter/formatter config
+(`ruff`/`black`) despite a Python-shaped `.gitignore`; consider a
+dev-requirements set if tests/lint are added.

--- a/README.md
+++ b/README.md
@@ -43,30 +43,30 @@ Swiss E-ID Ecosystem|[Link](https://github.com/e-id-admin)
 |Canton|Link|
 |------|----|
 Aargau|[GitHub Org](https://github.com/kanton-aargau)
-Appenzell Ausserrhoden|[GitHub Org]
+Appenzell Ausserrhoden|— none known yet
 Appenzell Innerrhoden|[GitHub Org](https://github.com/KTAI-GIS)
 Basel-Land|[Open Data](https://github.com/ogd-bl)
 Basel-Stadt|[Open Data](https://github.com/opendatabs)
 Bern|[GitHub Org](https://github.com/kanton-bern)
-Fribourg|[GitHub Org]
+Fribourg|— none known yet
 Geneva|[GitHub Org](https://github.com/republique-et-canton-de-geneve)
-Glarus|[GitHub Org]
-Graubüden|[GitHub Org]
-Jura|[GitHub Org]
-Lucerne|[GitHub Org]
+Glarus|— none known yet
+Graubünden|— none known yet
+Jura|— none known yet
+Lucerne|— none known yet
 Neuchâtel|[GitHub Org](https://github.com/sitn)
-Nidwalden|[GitHub Org]
-Obwalden|[GitHub Org]
-Schaffhausen|[GitHub Org]
-Schwyz|[GitHub Org]
+Nidwalden|— none known yet
+Obwalden|— none known yet
+Schaffhausen|— none known yet
+Schwyz|— none known yet
 Solothurn|[Geoinformation](https://github.com/sogis)
 St. Gallen|[Office of Statistics](https://github.com/statistikSG)
 Thurgau|[Open Data](https://github.com/ogdtg)
-Ticino|[GitHub Org]
-Uri|[GitHub Org]
-Valais|[GitHub Org]
+Ticino|— none known yet
+Uri|— none known yet
+Valais|— none known yet
 Vaud|[IT Office](https://github.com/dsi-vd)
-Zug|[GitHub Org]
+Zug|— none known yet
 Zürich|[Statistics I](https://github.com/statistikstadtzuerich)
 Zürich|[Office of Statistics II](https://github.com/statistikZH)
 Zürich|[Transport](https://github.com/VerkehrsbetriebeZuerich)

--- a/README.md
+++ b/README.md
@@ -78,6 +78,39 @@ Zürich|[AI + Machine Learning](https://github.com/machinelearningZH)
 
 <!-- END CANTONAL LIST -->
 
+## Contributing
+
+`README.md` is the **single source of truth**. The lists above are the two
+markdown tables delimited by the `<!-- BEGIN/END FEDERAL LIST -->` and
+`<!-- BEGIN/END CANTONAL LIST -->` comments. The per-entry files under `data/`
+are **generated** from them — never edit `data/` by hand.
+
+To add or update an organization:
+
+1. Edit the relevant table in `README.md`. Each row is `Name|[Link text](url)`.
+   For an authority with no known GitHub org, use plain text (e.g.
+   `Canton|— none known yet`) instead of a link.
+2. Regenerate the data files:
+   ```sh
+   pip install -r requirements.txt
+   python scripts/create_yamls.py
+   ```
+   The generator is idempotent and self-cleaning (it removes `data/` files that
+   no longer match a row).
+3. Commit both the `README.md` and `data/` changes.
+
+Each generated file has the schema:
+
+```yaml
+name: <display name>
+link_title: <link text, empty if none>
+link_url: <GitHub URL, empty if none>
+```
+
+Development tooling (optional): `pip install -r requirements-dev.txt` then
+`ruff check .` and `pytest`. CI enforces lint, tests, and that `data/` stays in
+sync with `README.md`.
+
 ## License 
 
 This repository assets, content and data folders are licensed under a [CC-BY license](./LICENSE). 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,288 @@
+# Spec: Swiss public-sector OSS inventory (`awesome-codeswissgov`)
+
+**Status:** Approved — Phase 1 (Specify) complete; decisions resolved. Moving to
+Phase 2 (Plan), Epic 0 first.
+**Companion:** `DESIGN.md` (strategy & rationale). This spec is the buildable
+contract; DESIGN is the "why".
+**Scope chosen:** Full harvester vision, delivered as sequenced epics.
+
+---
+
+## Objective
+
+Evolve the project from a hand-curated awesome-list into the **canonical,
+machine-readable inventory of Swiss public-sector open source**: who publishes,
+what they publish, under which license, and how healthy it is.
+
+**Architecture decision (assumed by this scope):** `data/` becomes the **source
+of truth**; `README.md` and `inventory.json` are **generated views**. This
+dissolves the manual two-way sync that causes today's drift/orphan bugs.
+
+**Primary users**
+- OSPO operators (coverage, license, staleness, EMBAG-visibility reporting).
+- Developers/citizens discovering Swiss gov open source.
+- Other registries (EU/Joinup, code.gouv.fr, Developers Italia) consuming our data.
+
+**What success looks like** — the system can answer, automatically and on a
+schedule: *which authorities publish anything; which repos lack a license or are
+stale; the language/license mix; where gov code reuses gov code.*
+
+**Non-goals (accepted limitations)**
+- **GitHub only.** GitLab (incl. self-hosted and openCoDE), Bitbucket, and other
+  forges are **out of scope**. Authorities that publish *only* off GitHub will
+  not appear, so coverage is "present on GitHub" — not "publishes open source".
+  This trade-off is deliberate (GitHub is the highest-yield single source) and
+  must be stated explicitly wherever coverage is reported, so the under-count is
+  not mistaken for "publishes nothing". Re-introducing other platforms is an
+  "ask first" scope change, not planned work.
+- **Federal + cantonal only.** Municipal authorities (~2,000 communes) are **out
+  of scope** as a coverage goal — exhaustive municipal crawling is mostly noise.
+  Municipal entries may be accepted by submission/allowlist later, but are not
+  pursued now. Adding municipal as a goal is an "ask first" scope change.
+
+---
+
+## Tech Stack
+
+- **Language:** Python 3.11+ (existing).
+- **Runtime deps:** `PyYAML` (existing); `httpx` (HTTP for the GitHub API);
+  `pydantic` v2 (typed models + validation). *Any further runtime dep is
+  "ask first".*
+- **Dev deps (`requirements-dev.txt`):** `pytest`, `pytest-httpx` (mock API),
+  `ruff` (lint + format).
+- **CI:** GitHub Actions (lint + test + sync gate on PR; scheduled harvest).
+- **Metadata standard:** align the data model with **`publiccode.yml`**
+  (Foundation for Public Code) and interoperate with **`code.json`** (code.gov).
+
+---
+
+## Commands
+
+```
+Install:   pip install -r requirements.txt -r requirements-dev.txt
+Lint:      ruff check . && ruff format --check .
+Format:    ruff format .
+Test:      pytest
+Coverage:  pytest --cov=codeswissgov --cov-report=term-missing
+
+# Application CLI (python -m codeswissgov <command>)
+Build:     python -m codeswissgov build        # regenerate README.md + inventory.json from data/
+Validate:  python -m codeswissgov validate     # schema-check data/ AND assert build is up to date
+Harvest:   python -m codeswissgov harvest --token $GITHUB_TOKEN   # enrich data/ from the GitHub API
+Discover:  python -m codeswissgov discover --token $GITHUB_TOKEN  # propose new orgs/repos (writes suggestions, never auto-adds)
+```
+
+---
+
+## Project Structure
+
+Target layout after the flip (migrated incrementally — see Epic 1):
+
+```
+src/codeswissgov/
+  __init__.py
+  __main__.py          → CLI dispatch (build | validate | harvest | discover)
+  models.py            → pydantic models: Authority, Organization, Repository
+  parse.py             → legacy README-table parser (Epic 0; removed after flip)
+  harvest/
+    github.py          → GitHub REST/GraphQL client (org → repos + metadata)
+  discover.py          → discovery vectors (Epic 5)
+  render/
+    readme.py          → data/ → README.md tables (between markers)
+    inventory.py       → data/ → inventory.json
+    reports.py         → coverage / license / staleness reports
+data/                  → SOURCE OF TRUTH (curated, git-tracked, small)
+  orgs/*.yaml          → one file per organization (curation + provenance)
+                         repo-level harvested data is NOT committed per-file;
+                         it lives in the generated inventory.json (decision #7)
+tests/                 → pytest unit + fixture-based tests
+  fixtures/            → recorded API responses
+.github/workflows/
+  ci.yml               → lint + test + validate (sync gate) on PR/push
+  harvest.yml          → scheduled (cron) harvest + auto-PR
+README.md              → GENERATED VIEW (do not hand-edit data rows)
+inventory.json         → GENERATED data product
+SPEC.md  DESIGN.md
+requirements.txt  requirements-dev.txt
+```
+
+---
+
+## Code Style
+
+- Keep the existing **Apache 2.0 header** on every source file.
+- **Type hints everywhere**; Google-style docstrings on public functions.
+- **pydantic models** for all records — no free-form dicts crossing module
+  boundaries. Validation lives in the model, not the caller.
+- **`ruff`** governs lint + format (line length 88, default rules). No manual
+  style debates.
+- Pure functions for parsing/rendering; I/O (HTTP, files) isolated at the edges
+  so the core is unit-testable without the network.
+
+```python
+# Copyright 2024 ospo.ch authors
+# Licensed under the Apache License, Version 2.0 (the "License"); ...
+
+from pydantic import BaseModel, Field, HttpUrl
+
+
+class Repository(BaseModel):
+    """A single source repository belonging to a Swiss authority."""
+
+    name: str
+    url: HttpUrl
+    authority: str = Field(description="e.g. 'federal', 'canton:ZH'")
+    license: str | None = Field(default=None, description="SPDX id; None = no license = compliance flag")
+    language: str | None = None
+    topics: list[str] = Field(default_factory=list)
+    archived: bool = False
+    last_activity: str | None = None          # ISO-8601 date
+    has_publiccode_yml: bool = False
+
+    @property
+    def is_compliance_flag(self) -> bool:
+        """True when the repo lacks a declared license."""
+        return self.license is None
+```
+
+---
+
+## Testing Strategy
+
+- **Framework:** `pytest`; tests in `tests/`, mirroring `src/` layout.
+- **Levels:**
+  - *Unit* — parsers, filename conversion, renderers, model validation. Must run
+    offline; no network.
+  - *Integration* — harvest clients tested against **recorded fixtures**
+    (`pytest-httpx`); never hit the live API in CI.
+  - *Golden* — `build` output (README tables + `inventory.json`) compared to
+    committed snapshots.
+- **Coverage:** ≥ 90% on `parse.py`, `models.py`, and `render/`.
+- **Regression seeds (must-have cases):** markdown link / no-link / accented
+  names (`Zürich`, `Graubünden`); missing table marker → clear error;
+  self-cleaning removes orphans; round-trip `data/ → README → parse` is stable.
+
+---
+
+## Boundaries
+
+**Always**
+- Run `ruff` + `pytest` before every commit.
+- Regenerate views from `data/` via `build`; never hand-edit generated rows.
+- Keep generators **idempotent and self-cleaning** (no orphan files).
+- Use **SPDX** license identifiers; pin dependency versions.
+- Cache API responses; design harvest for **incremental** updates.
+
+**Ask first**
+- Adding any runtime dependency or changing the data **schema/model**.
+- Changing CI workflows or the scheduled-harvest cadence.
+- Expanding **scope** to municipal authorities or non-GitHub platforms.
+- Bulk deletion of `data/` records; any destructive migration.
+- Restoring i18n / multilingual rendering.
+
+**Never**
+- Commit secrets or API tokens (use GitHub Actions secrets / env).
+- Surface private-repo data, or anything that amplifies a secret/PII leak.
+- Mark an organization **"official"** without recorded provenance.
+- Fabricate org/repo data — harvested fields come only from real API responses.
+- Remove failing tests to go green without explicit approval.
+
+---
+
+## Epics & Success Criteria
+
+Each epic is independently shippable and separately reviewable. Acceptance
+criteria are testable.
+
+### Epic 0 — Stabilize (README stays source; no flip yet) ✅ DONE
+Fold in the audit backlog so the tool is solid before the refactor.
+- [x] Generator is self-cleaning — the 3 committed orphans
+      (`admin_swiss_federal_office_of_energy/_chancellery/_archives.yaml`) are
+      gone and cannot recur.
+- [x] `Graubüden` → `Graubünden` fixed; data regenerated.
+- [x] Regex escape sequences use raw strings (no `DeprecationWarning`).
+- [x] 14 no-org cantons render as plain text `— none known yet`, not `[GitHub Org]`.
+- [x] Parser hardened: regex links, stripped fields, path-independent
+      (`__file__`-relative), clear error on missing marker.
+- [x] `ruff` + `pytest` wired; CI fails on lint error, test failure, **or**
+      README↔`data/` drift (the sync gate in `.github/workflows/ci.yml`).
+- [x] README has a "Contributing" section; unit tests cover the regression seeds.
+
+### Epic 1 — Architecture flip (+ schema shape)
+- [ ] `data/orgs/*.yaml` is source of truth; `python -m codeswissgov build`
+      regenerates `README.md` tables and `inventory.json` deterministically.
+- [ ] Existing entries migrated with no semantic loss (golden snapshot of README
+      is byte-stable across a build).
+- [ ] Org model shape is **`publiccode.yml`-compatible from the start**
+      (decision #6 — migrate the shape once, here, not twice).
+- [ ] CI `validate` gate now asserts `build` is up to date (not the old direction).
+
+### Epic 2 — Enrichment harvester (headline feature)
+- [ ] `harvest` expands each org into repos with license, language, topics,
+      activity, archived, `publiccode.yml`/`SECURITY.md` presence — written to
+      the generated **`inventory.json`**, not per-repo YAML (decision #7).
+- [ ] GraphQL, incremental + cached; read-only PAT lifts the rate limit
+      (decision #4).
+- [ ] Scheduled workflow opens an auto-PR with refreshed `inventory.json`
+      (human merges).
+
+### Epic 3 — Ecosystem interop
+- [ ] Ingest `swiss/index` programmatically as the **federal source**, plus ≥1
+      sibling registry to seed coverage (decision #1: superset + enrichment).
+- [ ] `inventory.json` documented & versioned; emit/consume `publiccode.yml`
+      for EU-ecosystem interop.
+
+### Epic 4 — Data integrity
+- [ ] Link-rot detection flags 404 / renamed / deleted orgs.
+- [ ] Archived/transferred repos detected and reflected in the inventory.
+
+### Epic 5 — Discovery & reporting
+- [ ] Discovery vectors (org expansion, heuristic search, domain `code.json`
+      probe) produce *suggestions* (never auto-adds).
+- [ ] Reports: license coverage %, stale/archived counts, **authority coverage**
+      ("who publishes nothing"), and an **EMBAG-visibility** view.
+
+### Epic 6 — Governance & community
+- [ ] Verified-official provenance/badge; suggestion issue templates;
+      contribution governance documented.
+
+---
+
+## Decisions (resolved)
+
+1. **Positioning vs. `swiss/index` → superset + enrichment.** Ingest
+   `swiss/index` programmatically as the federal source (don't hand-maintain
+   what upstream already owns); add cantonal breadth + harvested metadata. Not a
+   mirror. (Epic 3.)
+2. **Scope → federal + cantonal only.** Municipal is out of scope as a goal
+   (see Non-goals); accept by submission/allowlist later if ever.
+3. **i18n → English/structured inventory.** Structural fields in English;
+   original-language names/descriptions preserved verbatim. Any multilingual
+   citizen view would be a *generated view* off the same `data/`, never a fork
+   of the source. No translation maintenance.
+4. **GitHub auth → read-only fine-grained PAT** stored as a GitHub Actions
+   secret for the scheduled harvest; GraphQL to minimize calls. No GitHub App at
+   this scale. (Epic 2.)
+5. **"Official" verification → two-tier provenance with recorded evidence.**
+   `official: true` only with a stored `provenance` source: registry listing,
+   GitHub **verified-domain** match to `*.admin.ch`/`*.<canton>.ch`, or explicit
+   confirmation. Otherwise `official: false` (candidate). (Epic 6; field lands
+   in Epic 1 model.)
+6. **Schema timing → `publiccode.yml`-compatible model shape in Epic 1.**
+   Migrate the data shape once during the flip; defer full ecosystem
+   import/export to Epic 3.
+7. **Repo data volume → org-level YAML committed; repo data in `inventory.json`
+   only.** No per-repo YAML files. `data/orgs/*.yaml` is the small curated
+   source; `inventory.json` is the generated, diffable harvest artifact.
+
+---
+
+## Review checklist (Phase 1 gate)
+
+- [x] Covers the six core areas (objective, stack, commands, structure, style, testing).
+- [x] Boundaries defined (Always / Ask first / Never).
+- [x] Success criteria are specific and testable (per epic).
+- [x] Saved to the repository (`SPEC.md`).
+- [x] Open questions resolved (see Decisions).
+- [x] **Human reviewed and approved.** Cleared to advance to Phase 2 (Plan),
+      starting with the unblocked Epic 0.

--- a/data/admin_swiss_federal_archives.yaml
+++ b/data/admin_swiss_federal_archives.yaml
@@ -1,3 +1,0 @@
-name: Swiss Federal Archives
-link_title: Link
-link_url: https://github.com/SwissFederalArchives

--- a/data/admin_swiss_federal_chancellery.yaml
+++ b/data/admin_swiss_federal_chancellery.yaml
@@ -1,3 +1,0 @@
-name: Swiss Federal Chancellery
-link_title: Link
-link_url: https://github.com/swiss

--- a/data/admin_swiss_federal_office_of_energy.yaml
+++ b/data/admin_swiss_federal_office_of_energy.yaml
@@ -1,3 +1,0 @@
-name: Swiss Federal Office of Energy
-link_title: Link
-link_url: https://github.com/SFOE

--- a/data/appenzell_ausserrhoden.yaml
+++ b/data/appenzell_ausserrhoden.yaml
@@ -1,3 +1,3 @@
 name: Appenzell Ausserrhoden
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/fribourg.yaml
+++ b/data/fribourg.yaml
@@ -1,3 +1,3 @@
 name: Fribourg
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/glarus.yaml
+++ b/data/glarus.yaml
@@ -1,3 +1,3 @@
 name: Glarus
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/graubuden_github_org.yaml
+++ b/data/graubuden_github_org.yaml
@@ -1,3 +1,0 @@
-name: Graubüden
-link_title: GitHub Org
-link_url: ''

--- a/data/graubunden.yaml
+++ b/data/graubunden.yaml
@@ -1,0 +1,3 @@
+name: Graubünden
+link_title: ''
+link_url: ''

--- a/data/jura.yaml
+++ b/data/jura.yaml
@@ -1,3 +1,3 @@
 name: Jura
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/lucerne.yaml
+++ b/data/lucerne.yaml
@@ -1,3 +1,3 @@
 name: Lucerne
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/nidwalden.yaml
+++ b/data/nidwalden.yaml
@@ -1,3 +1,3 @@
 name: Nidwalden
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/obwalden.yaml
+++ b/data/obwalden.yaml
@@ -1,3 +1,3 @@
 name: Obwalden
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/schaffhausen.yaml
+++ b/data/schaffhausen.yaml
@@ -1,3 +1,3 @@
 name: Schaffhausen
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/schwyz.yaml
+++ b/data/schwyz.yaml
@@ -1,3 +1,3 @@
 name: Schwyz
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/ticino.yaml
+++ b/data/ticino.yaml
@@ -1,3 +1,3 @@
 name: Ticino
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/uri.yaml
+++ b/data/uri.yaml
@@ -1,3 +1,3 @@
 name: Uri
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/valais.yaml
+++ b/data/valais.yaml
@@ -1,3 +1,3 @@
 name: Valais
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/data/zug.yaml
+++ b/data/zug.yaml
@@ -1,3 +1,3 @@
 name: Zug
-link_title: GitHub Org
+link_title: ''
 link_url: ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+# Tooling configuration for awesome-codeswissgov.
+# Runtime deps live in requirements.txt; dev deps in requirements-dev.txt.
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W", "UP", "B"]
+
+[tool.pytest.ini_options]
+# The generator lives in scripts/ (no package yet — that arrives in Epic 1),
+# so expose it on the path for imports in tests.
+pythonpath = ["scripts"]
+testpaths = ["tests"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+ruff==0.8.4

--- a/scripts/create_yamls.py
+++ b/scripts/create_yamls.py
@@ -14,58 +14,75 @@
 #
 
 """
-This script generates yaml files from the README content
+This script generates yaml files from the README content.
+
+README.md is the single source of truth. Each row of the federal and cantonal
+tables is exported to one yaml file under data/ for machine consumption. The
+script is idempotent and self-cleaning: yaml files in data/ that no longer
+correspond to a README row are removed.
 """
 
-import yaml
-import unicodedata
 import re
+import sys
+import unicodedata
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README_PATH = REPO_ROOT / "README.md"
+DATA_DIR = REPO_ROOT / "data"
+
+# Matches a markdown link: [title](url)
+LINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]*)\)")
+
+
+def _extract_table(lines, header, end_marker):
+    """
+    Return the data rows of a markdown table delimited by ``header`` (the
+    ``|Col|Col|`` header line) and ``end_marker`` (an HTML comment closing the
+    list). The header separator row that follows the header is skipped, and
+    blank lines are dropped.
+    """
+    try:
+        start = lines.index(header) + 2
+        end = lines.index(end_marker) - 1
+    except ValueError as exc:
+        raise ValueError(
+            f"Could not locate table markers {header!r} / {end_marker!r} in "
+            f"{README_PATH}. Has the README structure changed?"
+        ) from exc
+    return [line for line in lines[start:end] if line.strip()]
 
 
 def read_readme():
     """
-    Read the default README file, extract the data from the federal services table
-    and the cantonal service table. Returns the content from both tables.
+    Read the README file and return the data rows of the federal services table
+    and the cantonal services table.
     """
-    with open("./README.md", "r", encoding="utf-8") as f:
-        content = f.readlines()
+    lines = README_PATH.read_text(encoding="utf-8").splitlines(keepends=True)
 
-        fed_table_start = "|Service|Link|\n"
-        fed_table_end = "<!-- END FEDERAL LIST -->\n"
-
-        canton_table_start = "|Canton|Link|\n"
-        canton_table_end = "<!-- END CANTONAL LIST -->\n"
-
-        fed_idx_start = content.index(fed_table_start) + 2
-        fed_idx_end = content.index(fed_table_end) - 1
-
-        canton_idx_start = content.index(canton_table_start) + 2
-        canton_idx_end = content.index(canton_table_end) - 1
-
-    return content[fed_idx_start:fed_idx_end], content[canton_idx_start:canton_idx_end]
+    fed = _extract_table(lines, "|Service|Link|\n", "<!-- END FEDERAL LIST -->\n")
+    canton = _extract_table(lines, "|Canton|Link|\n", "<!-- END CANTONAL LIST -->\n")
+    return fed, canton
 
 
 def parse_row(row: str):
     """
-    Parse the markdown content from a row based on the structure:
+    Parse a markdown table row of the form ``name|[link_title](link_url)``.
 
-    row
-        A markdown row with the format
-
-        name | \[link_title\](link_url)
-
+    Cells without a markdown link (plain-text placeholders such as
+    "— none known yet") yield empty ``link_title`` and ``link_url``.
     """
-    row_data = row.split("|")
-    name = row_data[0]
+    cells = [cell.strip() for cell in row.strip().split("|")]
+    name = cells[0]
     link_title = ""
     link_url = ""
 
-    if len(row_data) > 1:
-        title, url = row_data[1].strip().split("]", maxsplit=1)
-        link_title = title[1:]
-
-        if "(" in url and ")" in url:
-            link_url = url[1:-1]
+    if len(cells) > 1:
+        match = LINK_RE.search(cells[1])
+        if match:
+            link_title, link_url = match.group(1), match.group(2)
 
     return dict(
         name=name,
@@ -84,45 +101,55 @@ def convert_to_filename(name: str):
     https://github.com/django/django/blob/cdcd604ef8f650533eff6bd63a517ebb4ffddf96/django/utils/text.py#L452
     """
     name = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")
-    name = re.sub("[^\w\s]", "", name.lower())
-    name = re.sub("[-\s]+", "_", name).strip("_")
+    name = re.sub(r"[^\w\s]", "", name.lower())
+    name = re.sub(r"[-\s]+", "_", name).strip("_")
     return name
+
+
+def write_yaml(file_name: str, data: dict):
+    """Write ``data`` to ``data/<file_name>.yaml`` and return the path."""
+    path = DATA_DIR / f"{file_name}.yaml"
+    with path.open("w", encoding="utf-8") as file:
+        yaml.dump(
+            data,
+            file,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+    return path
 
 
 def create_yaml_files():
     """
-    Extract data from the README file and create yaml files for each entry.
+    Extract data from the README file and (re)create one yaml file per entry,
+    removing any stale yaml files that no longer match a README row.
     """
     fed, canton = read_readme()
+    DATA_DIR.mkdir(exist_ok=True)
+
+    written = set()
 
     # process federal service data
     for row in fed:
         data = parse_row(row)
         file_name = convert_to_filename("_".join(("admin", data["name"])))
-        with open(f"data/{file_name}.yaml", "w") as file:
-            yaml.dump(
-                data,
-                file,
-                default_flow_style=False,
-                allow_unicode=True,
-                sort_keys=False,
-            )
+        written.add(write_yaml(file_name, data))
 
     # process canton data
     for row in canton:
         data = parse_row(row)
-        file_name = convert_to_filename("_".join((data["name"], data["link_title"])))
-        with open(f"data/{file_name}.yaml", "w") as file:
-            yaml.dump(
-                data,
-                file,
-                default_flow_style=False,
-                allow_unicode=True,
-                sort_keys=False,
-            )
+        parts = [data["name"]]
+        if data["link_title"]:
+            parts.append(data["link_title"])
+        file_name = convert_to_filename("_".join(parts))
+        written.add(write_yaml(file_name, data))
+
+    # remove stale yaml files that are no longer backed by a README row
+    for existing in DATA_DIR.glob("*.yaml"):
+        if existing not in written:
+            existing.unlink()
 
 
 if __name__ == "__main__":
-    import sys
-
     sys.exit(create_yaml_files())

--- a/tests/test_create_yamls.py
+++ b/tests/test_create_yamls.py
@@ -1,0 +1,155 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for scripts/create_yamls.py (the README -> data/ generator)."""
+
+import create_yamls as cy
+import pytest
+
+MINIMAL_README = """\
+# Test
+
+## Federal
+
+<!-- BEGIN FEDERAL LIST -->
+
+|Service|Link|
+|-------|----|
+Swiss Admin|[Link](https://github.com/admin-ch)
+
+<!-- END FEDERAL LIST -->
+
+## Cantonal
+
+<!-- BEGIN CANTONAL LIST -->
+
+|Canton|Link|
+|------|----|
+Aargau|[GitHub Org](https://github.com/kanton-aargau)
+Jura|— none known yet
+
+<!-- END CANTONAL LIST -->
+"""
+
+
+# --- parse_row --------------------------------------------------------------
+
+
+def test_parse_row_with_link():
+    row = "Swiss Admin|[Link](https://github.com/admin-ch)\n"
+    assert cy.parse_row(row) == {
+        "name": "Swiss Admin",
+        "link_title": "Link",
+        "link_url": "https://github.com/admin-ch",
+    }
+
+
+def test_parse_row_plain_text_has_no_link():
+    """A cell without a markdown link yields empty link fields."""
+    assert cy.parse_row("Jura|— none known yet\n") == {
+        "name": "Jura",
+        "link_title": "",
+        "link_url": "",
+    }
+
+
+def test_parse_row_strips_surrounding_whitespace():
+    assert cy.parse_row("  Foo Bar  |  [T](http://x)  \n")["name"] == "Foo Bar"
+
+
+def test_parse_row_name_only_when_no_pipe():
+    assert cy.parse_row("Solo\n") == {
+        "name": "Solo",
+        "link_title": "",
+        "link_url": "",
+    }
+
+
+# --- convert_to_filename ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Zürich Open Data", "zurich_open_data"),
+        ("Graubünden", "graubunden"),
+        ("CDC-SI", "cdcsi"),
+        ("  spaced  ", "spaced"),
+        ("Basel-Land", "baselland"),  # punctuation (incl. '-') is stripped, not kept
+    ],
+)
+def test_convert_to_filename(value, expected):
+    assert cy.convert_to_filename(value) == expected
+
+
+# --- read_readme / _extract_table -------------------------------------------
+
+
+def test_extract_table_missing_marker_raises_clear_error():
+    with pytest.raises(ValueError, match="Could not locate table markers"):
+        cy._extract_table(
+            ["nothing here\n"],
+            "|Service|Link|\n",
+            "<!-- END FEDERAL LIST -->\n",
+        )
+
+
+def test_real_readme_parses_to_expected_counts():
+    fed, canton = cy.read_readme()
+    assert len(fed) == 25
+    assert len(canton) == 33
+
+
+# --- create_yaml_files (self-cleaning + idempotent) -------------------------
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    """Point the generator at a temporary README + data dir."""
+    readme = tmp_path / "README.md"
+    readme.write_text(MINIMAL_README, encoding="utf-8")
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setattr(cy, "README_PATH", readme)
+    monkeypatch.setattr(cy, "DATA_DIR", data_dir)
+    return data_dir
+
+
+def _yaml_names(data_dir):
+    return sorted(p.name for p in data_dir.glob("*.yaml"))
+
+
+def test_create_yaml_files_writes_expected_files(sandbox):
+    cy.create_yaml_files()
+    # _yaml_names returns sorted names; "jura.yaml" is the no-org canton whose
+    # filename is the canton name only (empty link_title).
+    assert _yaml_names(sandbox) == [
+        "aargau_github_org.yaml",
+        "admin_swiss_admin.yaml",
+        "jura.yaml",
+    ]
+
+
+def test_create_yaml_files_removes_orphans(sandbox):
+    (sandbox / "orphan.yaml").write_text("name: stale\n", encoding="utf-8")
+    cy.create_yaml_files()
+    assert "orphan.yaml" not in _yaml_names(sandbox)
+
+
+def test_create_yaml_files_is_idempotent(sandbox):
+    cy.create_yaml_files()
+    first = {p.name: p.read_text(encoding="utf-8") for p in sandbox.glob("*.yaml")}
+    cy.create_yaml_files()
+    second = {p.name: p.read_text(encoding="utf-8") for p in sandbox.glob("*.yaml")}
+    assert first == second


### PR DESCRIPTION
## Summary

Repository audit and stabilization (Epic 0), plus the planning docs that scope where this project is heading. README.md remains the source of truth; no architecture changes here.

### Bug fixes
- **Self-cleaning generator** — `scripts/create_yamls.py` now deletes `data/` files that no longer match a README row. Removes 3 orphaned files (`admin_swiss_federal_office_of_energy/_chancellery/_archives.yaml`) that were stranded by past renames.
- **Robust parser** — markdown links are matched with a regex, so plain-text cells no longer crash the script; fields are stripped; paths resolve from the script location (runs from any directory); a missing table marker raises a clear error.
- **Invalid escape sequences** fixed (raw-string regexes).
- **Typo** `Graubüden` → `Graubünden`.
- **Broken markdown** — the 14 cantons with no GitHub org rendered as literal `[GitHub Org]`; they now render as plain text `— none known yet`.

### Developer experience
- `pytest` unit tests for the generator (parsing, filename conversion, missing-marker error, self-cleaning, idempotency).
- `ruff` lint/format config and pinned dev requirements.
- **CI** (`.github/workflows/ci.yml`): ruff + pytest + a gate that regenerates `data/` and fails if it drifts from `README.md` — making README/`data/` desync impossible to merge.
- **Contributing** section documenting the edit → regenerate workflow and the `data/` schema.

### Planning docs
- `DESIGN.md` — strategy for evolving the awesome-list into a machine-readable Swiss public-sector OSS inventory (GitHub-only, federal + cantonal).
- `SPEC.md` — spec-driven contract with resolved decisions and the epic breakdown; Epic 0 is delivered by this PR.

## Verification
- `ruff check .`, `ruff format --check .` — clean
- `pytest` — 14 passed
- Generator is idempotent; `data/` regenerates with no drift

## Notes
Commits are isolated by concern (build / fix / tests / ci / docs). The `data/` changes show as renames (org-less canton files lose their `_github_org` suffix) plus the 3 orphan deletions.