### PR TITLE
Epic 2 — Enrichment harvester

### DIFF
--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -1,0 +1,56 @@
+name: Harvest
+
+# Scheduled enrichment harvest (SPEC Epic 2): refresh repo-level data in
+# inventory.json from the GitHub API and open a PR for a human to merge.
+#
+# Requires a repository secret HARVEST_GITHUB_TOKEN: a read-only fine-grained
+# PAT (SPEC decision #4) used only to lift the API rate limit. The pull request
+# itself is opened with the default GITHUB_TOKEN.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Mondays 04:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  harvest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -e . -r requirements-dev.txt
+
+      - name: Harvest repositories from GitHub
+        env:
+          GITHUB_TOKEN: ${{ secrets.HARVEST_GITHUB_TOKEN }}
+        run: python -m codeswissgov harvest
+
+      - name: Rebuild generated views
+        run: python -m codeswissgov build
+
+      - name: Validate data/orgs and generated views are in sync
+        run: python -m codeswissgov validate
+
+      - name: Open pull request with refreshed inventory
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: harvest/refresh-inventory
+          delete-branch: true
+          commit-message: "chore(harvest): refresh inventory.json"
+          title: "chore(harvest): refresh inventory.json"
+          labels: harvest
+          body: |
+            Automated harvest of repo-level data (license, language, topics,
+            activity, archived, publiccode.yml / SECURITY.md presence) from the
+            GitHub API into `inventory.json`.
+
+            Review the `inventory.json` diff before merging.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ Development tooling: `pip install -r requirements-dev.txt` then `ruff check .`
 and `pytest`. CI runs lint, tests, and `python -m codeswissgov validate`, which
 fails if `data/orgs/` is invalid or the generated views are out of date.
 
+### Repository-level data (harvest)
+
+`inventory.json` also carries **harvested** repo-level data per organization
+(license, language, topics, last activity, archived state, and `publiccode.yml`
+/ `SECURITY.md` presence). This is produced from the GitHub API — you do not
+edit it by hand:
+
+```sh
+python -m codeswissgov harvest --token "$GITHUB_TOKEN"   # read-only PAT
+```
+
+`harvest` is the only writer of repo-level data; `build` preserves it when it
+regenerates the views. A scheduled workflow refreshes it weekly and opens a PR.
+Coverage is **GitHub only** — authorities that publish solely off GitHub do not
+appear, so absence is not evidence that an authority publishes nothing.
+
 ## License 
 
 This repository assets, content and data folders are licensed under a [CC-BY license](./LICENSE). 

--- a/SPEC.md
+++ b/SPEC.md
@@ -220,14 +220,16 @@ Fold in the audit backlog so the tool is solid before the refactor.
 - [x] CI gate is now `python -m codeswissgov validate` (schema-check + assert
       views up to date), replacing the old README→`data/` sync direction.
 
-### Epic 2 — Enrichment harvester (headline feature)
-- [ ] `harvest` expands each org into repos with license, language, topics,
+### Epic 2 — Enrichment harvester (headline feature) ✅ DONE
+- [x] `harvest` expands each org into repos with license, language, topics,
       activity, archived, `publiccode.yml`/`SECURITY.md` presence — written to
-      the generated **`inventory.json`**, not per-repo YAML (decision #7).
-- [ ] GraphQL, incremental + cached; read-only PAT lifts the rate limit
-      (decision #4).
-- [ ] Scheduled workflow opens an auto-PR with refreshed `inventory.json`
-      (human merges).
+      the generated **`inventory.json`** (v2.0, repos nested under each org),
+      not per-repo YAML (decision #7).
+- [x] GraphQL, incremental + cached; read-only PAT lifts the rate limit
+      (decision #4). `inventory.json` is itself the cache: a failed org keeps
+      its prior repositories rather than being dropped.
+- [x] Scheduled workflow (`harvest.yml`) opens an auto-PR with refreshed
+      `inventory.json` (human merges).
 
 ### Epic 3 — Ecosystem interop
 - [ ] Ingest `swiss/index` programmatically as the **federal source**, plus ≥1

--- a/inventory.json
+++ b/inventory.json
@@ -1,313 +1,401 @@
 {
-  "schema_version": "1.0",
+  "schema_version": "2.0",
   "organizations": [
     {
       "name": "Armasuisse S+T",
       "authority": "federal",
       "url": "https://github.com/armasuissewt",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "CDC-SI",
       "authority": "federal",
       "url": "https://github.com/cdc-si/",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Coordination Agency for the Preservation of Electronic Files",
       "authority": "federal",
       "url": "https://github.com/KOST-CECO",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Data Science Competence Center",
       "authority": "federal",
       "url": "https://github.com/dscc-admin-ch",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Archives",
       "authority": "federal",
       "url": "https://github.com/SwissFederalArchives",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Chancellery",
       "authority": "federal",
       "url": "https://github.com/swiss",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Food Safety and Veterinary Office",
       "authority": "federal",
       "url": "https://github.com/BLV-OSAV-USAV",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Institute of Metrology",
       "authority": "federal",
       "url": "https://github.com/metas-ch",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Office for the Environment",
       "authority": "federal",
       "url": "https://github.com/foen-admin-ch",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Office of Energy",
       "authority": "federal",
       "url": "https://github.com/SFOE",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Office of Information Technology, Systems and Telecommunication",
       "authority": "federal",
       "url": "https://github.com/estv-admin",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Office of Statistics",
       "authority": "federal",
       "url": "https://github.com/BFS-SHS-MSAS",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Office of Topography",
       "authority": "federal",
       "url": "https://github.com/swisstopo",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Federal Statistical Office - Prices",
       "authority": "federal",
       "url": "https://github.com/FSO-PRICES",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "i14y Interoperability Platform",
       "authority": "federal",
       "url": "https://github.com/I14Y-ch",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "MeteoSwiss",
       "authority": "federal",
       "url": "https://github.com/MeteoSwiss",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Open Data Portal",
       "authority": "federal",
       "url": "https://github.com/opendata-swiss",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Open Government Data",
       "authority": "federal",
       "url": "https://github.com/ogdch",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Public Employment Service",
       "authority": "federal",
       "url": "https://github.com/alv-ch",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Swiss Admin",
       "authority": "federal",
       "url": "https://github.com/admin-ch",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Swiss Armed Forces",
       "authority": "federal",
       "url": "https://github.com/Swiss-Armed-Forces",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Swiss E-ID Ecosystem",
       "authority": "federal",
       "url": "https://github.com/e-id-admin",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Swiss Geoportal",
       "authority": "federal",
       "url": "https://github.com/geoadmin",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Swiss National Library",
       "authority": "federal",
       "url": "https://github.com/SwissNationalLibrary",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Territorial Data Lab",
       "authority": "federal",
       "url": "https://github.com/swiss-territorial-data-lab",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "GitHub Org",
       "authority": "canton:AG",
       "url": "https://github.com/kanton-aargau",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "GitHub Org",
       "authority": "canton:AI",
       "url": "https://github.com/KTAI-GIS",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Open Data",
       "authority": "canton:BL",
       "url": "https://github.com/ogd-bl",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Open Data",
       "authority": "canton:BS",
       "url": "https://github.com/opendatabs",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "GitHub Org",
       "authority": "canton:BE",
       "url": "https://github.com/kanton-bern",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "GitHub Org",
       "authority": "canton:GE",
       "url": "https://github.com/republique-et-canton-de-geneve",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "GitHub Org",
       "authority": "canton:NE",
       "url": "https://github.com/sitn",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Geoinformation",
       "authority": "canton:SO",
       "url": "https://github.com/sogis",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Office of Statistics",
       "authority": "canton:SG",
       "url": "https://github.com/statistikSG",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Open Data",
       "authority": "canton:TG",
       "url": "https://github.com/ogdtg",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "IT Office",
       "authority": "canton:VD",
       "url": "https://github.com/dsi-vd",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "AI + Machine Learning",
       "authority": "canton:ZH",
       "url": "https://github.com/machinelearningZH",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Geoinformation",
       "authority": "canton:ZH",
       "url": "https://github.com/gisktzh",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Nature Conservation",
       "authority": "canton:ZH",
       "url": "https://github.com/FNSKtZH",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Office of Statistics II",
       "authority": "canton:ZH",
       "url": "https://github.com/statistikZH",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Open Data",
       "authority": "canton:ZH",
       "url": "https://github.com/opendatazurich",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Open Data - Specialist Unit",
       "authority": "canton:ZH",
       "url": "https://github.com/openZH",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Statistics I",
       "authority": "canton:ZH",
       "url": "https://github.com/statistikstadtzuerich",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     },
     {
       "name": "Transport",
       "authority": "canton:ZH",
       "url": "https://github.com/VerkehrsbetriebeZuerich",
       "official": false,
-      "provenance": null
+      "provenance": null,
+      "harvested_at": null,
+      "repositories": []
     }
   ]
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest==8.3.4
+pytest-httpx==0.35.0
 ruff==0.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyYAML==6.0.2
 pydantic==2.13.4
+httpx==0.28.1

--- a/src/codeswissgov/__main__.py
+++ b/src/codeswissgov/__main__.py
@@ -12,26 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CLI entry point: ``python -m codeswissgov <build|validate>``.
+"""CLI entry point: ``python -m codeswissgov <build|validate|harvest>``.
 
 ``build``    regenerate README.md + inventory.json from data/orgs.
 ``validate`` schema-check data/orgs and assert the generated views are current.
+``harvest``  enrich inventory.json with repo-level data from the GitHub API.
 """
 
+import os
 import sys
 
 from .build import build, validate
+from .harvest import run_harvest
 
-USAGE = "usage: python -m codeswissgov <build|validate>"
+USAGE = "usage: python -m codeswissgov <build|validate|harvest [--token TOKEN]>"
 
 
-def _cmd_build() -> int:
+def _cmd_build(args: list[str]) -> int:
     result = build()
     print(f"built {result.readme_path.name} and {result.inventory_path.name}")
     return 0
 
 
-def _cmd_validate() -> int:
+def _cmd_validate(args: list[str]) -> int:
     try:
         stale = validate()
     except ValueError as exc:
@@ -48,7 +51,41 @@ def _cmd_validate() -> int:
     return 0
 
 
-COMMANDS = {"build": _cmd_build, "validate": _cmd_validate}
+def _cmd_harvest(args: list[str]) -> int:
+    token = _token(args)
+    if not token:
+        print(
+            "harvest: a read-only token is required "
+            "(--token TOKEN or $GITHUB_TOKEN).",
+            file=sys.stderr,
+        )
+        return 2
+    summary = run_harvest(token)
+    print(
+        f"harvest: refreshed {summary.orgs_refreshed}/{summary.orgs_total} orgs, "
+        f"{summary.repos_total} repos in inventory.json"
+    )
+    if summary.orgs_failed:
+        print(
+            f"harvest: {len(summary.orgs_failed)} org(s) kept cached data: "
+            f"{', '.join(summary.orgs_failed)}",
+            file=sys.stderr,
+        )
+    # Non-zero only when nothing could be refreshed (e.g. a bad token).
+    return 1 if summary.orgs_failed and summary.orgs_refreshed == 0 else 0
+
+
+def _token(args: list[str]) -> str | None:
+    """Resolve a token from ``--token VALUE``/``--token=VALUE`` or env."""
+    for i, arg in enumerate(args):
+        if arg == "--token" and i + 1 < len(args):
+            return args[i + 1]
+        if arg.startswith("--token="):
+            return arg[len("--token=") :]
+    return os.environ.get("GITHUB_TOKEN")
+
+
+COMMANDS = {"build": _cmd_build, "validate": _cmd_validate, "harvest": _cmd_harvest}
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -64,7 +101,7 @@ def main(argv: list[str] | None = None) -> int:
     if handler is None:
         print(USAGE, file=sys.stderr)
         return 2
-    return handler()
+    return handler(argv[1:])
 
 
 if __name__ == "__main__":

--- a/src/codeswissgov/build.py
+++ b/src/codeswissgov/build.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .loader import load_organizations
-from .render.inventory import render_inventory
+from .render.inventory import load_harvest, render_inventory
 from .render.readme import render_readme
 
 # Repo root: src/codeswissgov/build.py -> parents[2].
@@ -39,15 +39,23 @@ class RenderResult:
 
 
 def render_all(root: Path = DEFAULT_ROOT) -> RenderResult:
-    """Render both views in memory (no writes). Used by build and validate."""
+    """Render both views in memory (no writes). Used by build and validate.
+
+    Repo-level harvest data lives only in ``inventory.json`` (SPEC decision #7),
+    so the prior file is read back and its ``repositories`` carried forward —
+    ``build`` regenerates org-level fields offline without discarding harvest.
+    """
     readme_path = root / "README.md"
     inventory_path = root / "inventory.json"
     orgs = load_organizations(root / "data" / "orgs")
+    prior_inventory = (
+        inventory_path.read_text(encoding="utf-8") if inventory_path.exists() else ""
+    )
     return RenderResult(
         readme_path=readme_path,
         readme_text=render_readme(orgs, readme_path.read_text(encoding="utf-8")),
         inventory_path=inventory_path,
-        inventory_text=render_inventory(orgs),
+        inventory_text=render_inventory(orgs, load_harvest(prior_inventory)),
     )
 
 

--- a/src/codeswissgov/harvest/__init__.py
+++ b/src/codeswissgov/harvest/__init__.py
@@ -14,6 +14,109 @@
 
 """Enrichment harvester: expand curated orgs into repo-level inventory data.
 
-Network I/O is isolated in :mod:`codeswissgov.harvest.github`; orchestration
-(merging harvested repos into ``inventory.json``) lives alongside it.
+Network I/O is isolated in :mod:`codeswissgov.harvest.github`; this module
+orchestrates the harvest and merges the results into ``inventory.json`` — the
+single committed carrier of repo-level data (SPEC decision #7).
+
+The harvest is incremental and cache-backed: each org is fetched independently,
+and ``inventory.json`` itself is the cache. When an org fetch fails, its prior
+repositories are carried forward unchanged rather than dropped, so a transient
+error never wipes good data and partial progress always persists.
 """
+
+import sys
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+
+import httpx
+
+from ..build import DEFAULT_ROOT
+from ..loader import load_organizations
+from ..render.inventory import OrgHarvest, load_harvest, render_inventory
+from .github import GitHubClient, GitHubError
+
+
+@dataclass(frozen=True)
+class HarvestSummary:
+    """Outcome of a harvest run, for CLI reporting."""
+
+    orgs_total: int
+    orgs_refreshed: int
+    repos_total: int
+    orgs_failed: list[str] = field(default_factory=list)
+
+
+def org_login(url: str) -> str:
+    """Extract the GitHub org login from an organization URL.
+
+    ``https://github.com/admin-ch`` and ``.../cdc-si/`` both -> the last
+    path segment, tolerating a trailing slash.
+    """
+    return url.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def run_harvest(
+    token: str,
+    root: Path = DEFAULT_ROOT,
+    *,
+    github: GitHubClient | None = None,
+    now: str | None = None,
+) -> HarvestSummary:
+    """Harvest every org's repositories and rewrite ``inventory.json``.
+
+    Args:
+        token: Read-only PAT (used only to build the default client).
+        root: Repository root containing ``data/orgs`` and ``inventory.json``.
+        github: Injected client (tests); a real one is built from ``token`` if
+            omitted.
+        now: Timestamp to stamp on refreshed orgs; defaults to UTC now.
+
+    Returns:
+        A :class:`HarvestSummary` of what was refreshed, cached, or failed.
+    """
+    orgs = load_organizations(root / "data" / "orgs")
+    inventory_path = root / "inventory.json"
+    prior = load_harvest(
+        inventory_path.read_text(encoding="utf-8") if inventory_path.exists() else ""
+    )
+    timestamp = now or _utc_now()
+
+    owns_client = github is None
+    http_client = httpx.Client(timeout=30.0) if owns_client else None
+    github = github or GitHubClient(token=token, client=http_client)
+
+    harvest: dict[str, OrgHarvest] = {}
+    failed: list[str] = []
+    try:
+        for org in orgs:
+            login = org_login(org.url)
+            try:
+                repositories = github.fetch_org_repositories(login)
+            except GitHubError as exc:
+                failed.append(login)
+                if org.url in prior:
+                    harvest[org.url] = prior[org.url]  # keep cached data
+                print(
+                    f"harvest: {login} failed, keeping cached data: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            harvest[org.url] = OrgHarvest(
+                harvested_at=timestamp, repositories=repositories
+            )
+    finally:
+        if owns_client:
+            http_client.close()
+
+    inventory_path.write_text(render_inventory(orgs, harvest), encoding="utf-8")
+    return HarvestSummary(
+        orgs_total=len(orgs),
+        orgs_refreshed=len(orgs) - len(failed),
+        repos_total=sum(len(h.repositories) for h in harvest.values()),
+        orgs_failed=failed,
+    )

--- a/src/codeswissgov/harvest/__init__.py
+++ b/src/codeswissgov/harvest/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Enrichment harvester: expand curated orgs into repo-level inventory data.
+
+Network I/O is isolated in :mod:`codeswissgov.harvest.github`; orchestration
+(merging harvested repos into ``inventory.json``) lives alongside it.
+"""

--- a/src/codeswissgov/harvest/github.py
+++ b/src/codeswissgov/harvest/github.py
@@ -1,0 +1,141 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GitHub GraphQL client: expand an org into :class:`Repository` records.
+
+GraphQL keeps the harvest to one paginated request per org (SPEC decision #4),
+fetching license, language, topics, archived state, last activity, and the
+presence of ``publiccode.yml`` / ``SECURITY.md`` in a single round trip. All
+network I/O is confined here; the ``httpx.Client`` is injected so tests run
+offline against recorded fixtures.
+"""
+
+from dataclasses import dataclass
+
+import httpx
+
+from ..models import Repository
+
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+# One page of an org's source repositories with everything Epic 2 needs. Forks
+# are excluded (ownership/curation noise). File presence uses HEAD:<path>, which
+# resolves to null when the file is absent.
+_QUERY = """
+query($login: String!, $cursor: String) {
+  organization(login: $login) {
+    repositories(
+      first: 100
+      after: $cursor
+      isFork: false
+      ownerAffiliations: OWNER
+      orderBy: {field: NAME, direction: ASC}
+    ) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        name
+        url
+        isArchived
+        pushedAt
+        primaryLanguage { name }
+        licenseInfo { spdxId }
+        repositoryTopics(first: 100) { nodes { topic { name } } }
+        publiccode: object(expression: "HEAD:publiccode.yml") { __typename }
+        security: object(expression: "HEAD:SECURITY.md") { __typename }
+      }
+    }
+  }
+}
+"""
+
+
+class GitHubError(RuntimeError):
+    """A GraphQL request failed, returned errors, or the org was not found."""
+
+
+@dataclass
+class GitHubClient:
+    """Thin GraphQL client for harvesting one org's repositories.
+
+    Attributes:
+        token: Read-only fine-grained PAT (decision #4); sent as a bearer token.
+        client: Injected ``httpx.Client`` so callers/tests control transport.
+        url: GraphQL endpoint (overridable for testing).
+    """
+
+    token: str
+    client: httpx.Client
+    url: str = GITHUB_GRAPHQL_URL
+
+    def fetch_org_repositories(self, login: str) -> list[Repository]:
+        """Return every source repository for ``login`` (paginated, ordered).
+
+        Raises:
+            GitHubError: transport failure, GraphQL errors, or unknown org.
+        """
+        repositories: list[Repository] = []
+        cursor: str | None = None
+        while True:
+            organization = self._post(login, cursor)["data"]["organization"]
+            if organization is None:
+                raise GitHubError(f"organization not found or inaccessible: {login}")
+            connection = organization["repositories"]
+            repositories.extend(_repository(node) for node in connection["nodes"])
+            page = connection["pageInfo"]
+            if not page["hasNextPage"]:
+                return repositories
+            cursor = page["endCursor"]
+
+    def _post(self, login: str, cursor: str | None) -> dict:
+        try:
+            response = self.client.post(
+                self.url,
+                json={
+                    "query": _QUERY,
+                    "variables": {"login": login, "cursor": cursor},
+                },
+                headers={
+                    "Authorization": f"bearer {self.token}",
+                    "User-Agent": "awesome-codeswissgov-harvester",
+                },
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise GitHubError(f"GitHub request failed for {login}: {exc}") from exc
+        payload = response.json()
+        if payload.get("errors"):
+            raise GitHubError(f"GraphQL errors for {login}: {payload['errors']}")
+        return payload
+
+
+def _repository(node: dict) -> Repository:
+    """Build a :class:`Repository` from one GraphQL repository node."""
+    license_info = node.get("licenseInfo") or {}
+    language = node.get("primaryLanguage") or {}
+    topics = [edge["topic"]["name"] for edge in node["repositoryTopics"]["nodes"]]
+    pushed_at = node.get("pushedAt")
+    return Repository(
+        name=node["name"],
+        url=node["url"],
+        # null = no license = compliance flag; spdxId verbatim otherwise.
+        license=license_info.get("spdxId"),
+        language=language.get("name"),
+        topics=topics,
+        archived=node["isArchived"],
+        # Date only: pushedAt is a timestamp, but per-second churn would make
+        # every harvest diff noisy. ISO-8601 date matches the model's semantics.
+        last_activity=pushed_at[:10] if pushed_at else None,
+        has_publiccode_yml=node.get("publiccode") is not None,
+        has_security_md=node.get("security") is not None,
+    )

--- a/src/codeswissgov/models.py
+++ b/src/codeswissgov/models.py
@@ -19,7 +19,7 @@
 modelled here — they arrive in ``inventory.json`` in Epic 2 (decision #7).
 """
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .cantons import CANTON_CODES
 
@@ -104,3 +104,57 @@ class Organization(BaseModel):
         if self.authority.startswith(CANTON_PREFIX):
             return self.authority[len(CANTON_PREFIX) :]
         return None
+
+
+class Repository(BaseModel):
+    """A harvested source repository belonging to an organization.
+
+    Repo-level records are *not* curated in ``data/orgs`` (SPEC decision #7);
+    they are produced by ``harvest`` from real GitHub API responses and live
+    only in the generated ``inventory.json``, nested under their organization.
+    ``authority`` is therefore omitted here (derivable from the parent org).
+
+    Attributes:
+        name: Repository name (within the org).
+        url: GitHub repository URL.
+        license: SPDX identifier, or ``None`` when no license is declared.
+            ``None`` is a compliance flag, not missing data.
+        language: Primary language reported by GitHub, or ``None``.
+        topics: Repository topics (may be empty).
+        archived: Whether GitHub marks the repo as archived.
+        last_activity: ISO-8601 date of the last push, or ``None``.
+        has_publiccode_yml: Whether a ``publiccode.yml`` exists at the repo root.
+        has_security_md: Whether a ``SECURITY.md`` exists at the repo root.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    url: str
+    license: str | None = None
+    language: str | None = None
+    topics: list[str] = Field(default_factory=list)
+    archived: bool = False
+    last_activity: str | None = None
+    has_publiccode_yml: bool = False
+    has_security_md: bool = False
+
+    @field_validator("name")
+    @classmethod
+    def _name_non_empty(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("name must not be empty")
+        return value
+
+    @field_validator("url")
+    @classmethod
+    def _url_is_github(cls, value: str) -> str:
+        if not value.startswith(_GITHUB_PREFIX):
+            raise ValueError(f"url must be a {_GITHUB_PREFIX} URL, got {value!r}")
+        return value
+
+    @property
+    def is_compliance_flag(self) -> bool:
+        """True when the repo lacks a declared license."""
+        return self.license is None

--- a/src/codeswissgov/render/inventory.py
+++ b/src/codeswissgov/render/inventory.py
@@ -12,25 +12,76 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Render ``data/orgs`` into the ``inventory.json`` data product.
+"""Render ``data/orgs`` (+ harvested repos) into the ``inventory.json`` product.
 
-Epic 1 ships an **org-level** inventory (no repo-level data — that arrives in
-Epic 2, SPEC decision #7). Output is deterministic: canonical render order,
-two-space indent, trailing newline, non-ASCII preserved.
+``inventory.json`` is the **single** committed artifact that carries repo-level
+data (SPEC decision #7). ``harvest`` is the sole writer of that repo data;
+``build`` regenerates the org-level fields from ``data/orgs`` while *preserving*
+the ``repositories``/``harvested_at`` blocks already present, so it stays offline
+and deterministic. Output is canonical: render order, two-space indent, trailing
+newline, non-ASCII preserved.
 """
 
 import json
+from dataclasses import dataclass, field
 
-from ..models import Organization
+from ..models import Organization, Repository
 from . import render_order
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "2.0"
 
 
-def render_inventory(orgs: list[Organization]) -> str:
-    """Return the ``inventory.json`` text for ``orgs``."""
+@dataclass(frozen=True)
+class OrgHarvest:
+    """Harvested repo-level data for one organization (keyed elsewhere by url)."""
+
+    harvested_at: str | None = None
+    repositories: list[Repository] = field(default_factory=list)
+
+
+def load_harvest(inventory_text: str) -> dict[str, OrgHarvest]:
+    """Parse repo-level harvest data from an existing ``inventory.json``.
+
+    Returns a mapping of org ``url`` -> :class:`OrgHarvest`. Org-level fields are
+    ignored (they are regenerated from ``data/orgs``); only ``harvested_at`` and
+    ``repositories`` are carried forward, the latter validated through the model
+    so corruption surfaces clearly. Empty/blank text yields an empty mapping.
+    """
+    if not inventory_text.strip():
+        return {}
+    data = json.loads(inventory_text)
+    harvest: dict[str, OrgHarvest] = {}
+    for entry in data.get("organizations", []):
+        repos = [Repository(**r) for r in entry.get("repositories", [])]
+        harvest[entry["url"]] = OrgHarvest(
+            harvested_at=entry.get("harvested_at"),
+            repositories=repos,
+        )
+    return harvest
+
+
+def render_inventory(
+    orgs: list[Organization],
+    harvest: dict[str, OrgHarvest] | None = None,
+) -> str:
+    """Return the ``inventory.json`` text for ``orgs`` plus any harvested repos.
+
+    ``harvest`` maps org ``url`` -> :class:`OrgHarvest`; orgs without an entry
+    render with ``harvested_at: null`` and an empty ``repositories`` list.
+    """
+    harvest = harvest or {}
     payload = {
         "schema_version": SCHEMA_VERSION,
-        "organizations": [o.model_dump() for o in render_order(orgs)],
+        "organizations": [
+            _org_entry(o, harvest.get(o.url)) for o in render_order(orgs)
+        ],
     }
     return json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+
+
+def _org_entry(org: Organization, harvested: OrgHarvest | None) -> dict:
+    entry = org.model_dump()
+    entry["harvested_at"] = harvested.harvested_at if harvested else None
+    repos = harvested.repositories if harvested else []
+    entry["repositories"] = [r.model_dump() for r in repos]
+    return entry

--- a/tests/fixtures/graphql_org_not_found.json
+++ b/tests/fixtures/graphql_org_not_found.json
@@ -1,0 +1,3 @@
+{
+  "data": { "organization": null }
+}

--- a/tests/fixtures/graphql_org_page1.json
+++ b/tests/fixtures/graphql_org_page1.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "organization": {
+      "repositories": {
+        "pageInfo": { "hasNextPage": true, "endCursor": "Y3Vyc29yOjE=" },
+        "nodes": [
+          {
+            "name": "alpha",
+            "url": "https://github.com/admin-ch/alpha",
+            "isArchived": false,
+            "pushedAt": "2026-02-01T08:00:00Z",
+            "primaryLanguage": { "name": "Go" },
+            "licenseInfo": { "spdxId": "Apache-2.0" },
+            "repositoryTopics": { "nodes": [] },
+            "publiccode": null,
+            "security": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/graphql_org_page2.json
+++ b/tests/fixtures/graphql_org_page2.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "organization": {
+      "repositories": {
+        "pageInfo": { "hasNextPage": false, "endCursor": "Y3Vyc29yOjI=" },
+        "nodes": [
+          {
+            "name": "beta",
+            "url": "https://github.com/admin-ch/beta",
+            "isArchived": false,
+            "pushedAt": "2026-03-10T12:00:00Z",
+            "primaryLanguage": { "name": "Rust" },
+            "licenseInfo": { "spdxId": "GPL-3.0" },
+            "repositoryTopics": { "nodes": [{ "topic": { "name": "cli" } }] },
+            "publiccode": { "__typename": "Blob" },
+            "security": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/fixtures/graphql_org_single.json
+++ b/tests/fixtures/graphql_org_single.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "organization": {
+      "repositories": {
+        "pageInfo": { "hasNextPage": false, "endCursor": "Y3Vyc29yOjI=" },
+        "nodes": [
+          {
+            "name": "open-tool",
+            "url": "https://github.com/admin-ch/open-tool",
+            "isArchived": false,
+            "pushedAt": "2026-01-15T10:30:00Z",
+            "primaryLanguage": { "name": "Python" },
+            "licenseInfo": { "spdxId": "MIT" },
+            "repositoryTopics": {
+              "nodes": [
+                { "topic": { "name": "government" } },
+                { "topic": { "name": "switzerland" } }
+              ]
+            },
+            "publiccode": { "__typename": "Blob" },
+            "security": { "__typename": "Blob" }
+          },
+          {
+            "name": "legacy-archive",
+            "url": "https://github.com/admin-ch/legacy-archive",
+            "isArchived": true,
+            "pushedAt": null,
+            "primaryLanguage": null,
+            "licenseInfo": null,
+            "repositoryTopics": { "nodes": [] },
+            "publiccode": null,
+            "security": null
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,3 +94,65 @@ def test_cli_no_command_is_usage_error(capsys):
 
 def test_cli_unknown_command_is_usage_error():
     assert cli.main(["frobnicate"]) == 2
+
+
+# --- harvest command --------------------------------------------------------
+
+
+def test_harvest_requires_a_token(monkeypatch, capsys):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    assert cli.main(["harvest"]) == 2
+    assert "token is required" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "argv,env,expected",
+    [
+        (["harvest", "--token", "flag-tok"], None, "flag-tok"),
+        (["harvest", "--token=eq-tok"], None, "eq-tok"),
+        (["harvest"], "env-tok", "env-tok"),
+        (["harvest", "--token", "flag-wins"], "env-tok", "flag-wins"),
+    ],
+)
+def test_harvest_token_resolution(monkeypatch, argv, env, expected):
+    if env is None:
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    else:
+        monkeypatch.setenv("GITHUB_TOKEN", env)
+    seen = {}
+
+    def fake_run_harvest(token):
+        seen["token"] = token
+        return _summary(refreshed=1)
+
+    monkeypatch.setattr(cli, "run_harvest", fake_run_harvest)
+    assert cli.main(argv) == 0
+    assert seen["token"] == expected
+
+
+def test_harvest_reports_failures_but_succeeds(monkeypatch, capsys):
+    monkeypatch.setattr(
+        cli, "run_harvest", lambda token: _summary(refreshed=3, failed=["x"])
+    )
+    assert cli.main(["harvest", "--token", "t"]) == 0
+    err = capsys.readouterr().err
+    assert "kept cached data" in err
+
+
+def test_harvest_returns_nonzero_when_nothing_refreshed(monkeypatch):
+    monkeypatch.setattr(
+        cli, "run_harvest", lambda token: _summary(refreshed=0, failed=["x", "y"])
+    )
+    assert cli.main(["harvest", "--token", "t"]) == 1
+
+
+def _summary(*, refreshed, failed=None):
+    from codeswissgov.harvest import HarvestSummary
+
+    failed = failed or []
+    return HarvestSummary(
+        orgs_total=refreshed + len(failed),
+        orgs_refreshed=refreshed,
+        repos_total=refreshed,
+        orgs_failed=failed,
+    )

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -1,0 +1,136 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for harvest orchestration (offline; injected client)."""
+
+import json
+
+import pytest
+
+from codeswissgov.harvest import org_login, run_harvest
+from codeswissgov.harvest.github import GitHubError
+from codeswissgov.models import Repository
+
+
+class FakeGitHub:
+    """Stand-in for GitHubClient: returns canned repos, errors on listed logins."""
+
+    def __init__(self, repos_by_login, errors=()):
+        self.repos_by_login = repos_by_login
+        self.errors = set(errors)
+        self.calls = []
+
+    def fetch_org_repositories(self, login):
+        self.calls.append(login)
+        if login in self.errors:
+            raise GitHubError(f"boom: {login}")
+        return self.repos_by_login.get(login, [])
+
+
+def _repo(handle, name, **kw):
+    return Repository(name=name, url=f"https://github.com/{handle}/{name}", **kw)
+
+
+def _make_root(tmp_path, orgs):
+    """Scaffold a repo root with data/orgs/*.yaml (federal) for given handles."""
+    orgs_dir = tmp_path / "data" / "orgs"
+    orgs_dir.mkdir(parents=True)
+    for handle in orgs:
+        (orgs_dir / f"{handle}.yaml").write_text(
+            f"name: {handle}\nauthority: federal\nurl: https://github.com/{handle}\n"
+        )
+    return tmp_path
+
+
+def _inventory(root):
+    return json.loads((root / "inventory.json").read_text(encoding="utf-8"))
+
+
+def test_harvest_writes_repos_and_timestamp(tmp_path):
+    root = _make_root(tmp_path, ["admin-ch", "swiss"])
+    github = FakeGitHub(
+        {
+            "admin-ch": [_repo("admin-ch", "tool", license="MIT")],
+            "swiss": [_repo("swiss", "index"), _repo("swiss", "site")],
+        }
+    )
+    summary = run_harvest("t", root, github=github, now="2026-06-05T00:00:00Z")
+
+    assert summary.orgs_total == 2
+    assert summary.orgs_refreshed == 2
+    assert summary.repos_total == 3
+    assert summary.orgs_failed == []
+
+    by_url = {o["url"]: o for o in _inventory(root)["organizations"]}
+    admin = by_url["https://github.com/admin-ch"]
+    assert admin["harvested_at"] == "2026-06-05T00:00:00Z"
+    assert [r["name"] for r in admin["repositories"]] == ["tool"]
+    assert admin["repositories"][0]["license"] == "MIT"
+    assert len(by_url["https://github.com/swiss"]["repositories"]) == 2
+
+
+def test_harvest_keeps_cached_data_on_failure(tmp_path):
+    root = _make_root(tmp_path, ["admin-ch", "swiss"])
+    # First, successful run populates both.
+    github = FakeGitHub(
+        {
+            "admin-ch": [_repo("admin-ch", "tool")],
+            "swiss": [_repo("swiss", "index")],
+        }
+    )
+    run_harvest("t", root, github=github, now="2026-01-01T00:00:00Z")
+
+    # Second run: admin-ch fails, swiss refreshes with a new repo set.
+    github2 = FakeGitHub(
+        {"swiss": [_repo("swiss", "index"), _repo("swiss", "new")]},
+        errors=["admin-ch"],
+    )
+    summary = run_harvest("t", root, github=github2, now="2026-02-02T00:00:00Z")
+
+    assert summary.orgs_failed == ["admin-ch"]
+    assert summary.orgs_refreshed == 1
+
+    by_url = {o["url"]: o for o in _inventory(root)["organizations"]}
+    admin = by_url["https://github.com/admin-ch"]
+    swiss = by_url["https://github.com/swiss"]
+    # admin-ch retains the prior snapshot verbatim (cache fallback).
+    assert admin["harvested_at"] == "2026-01-01T00:00:00Z"
+    assert [r["name"] for r in admin["repositories"]] == ["tool"]
+    # swiss got the fresh data + new timestamp.
+    assert swiss["harvested_at"] == "2026-02-02T00:00:00Z"
+    assert [r["name"] for r in swiss["repositories"]] == ["index", "new"]
+
+
+def test_harvest_first_failure_leaves_org_empty(tmp_path):
+    root = _make_root(tmp_path, ["admin-ch"])
+    github = FakeGitHub({}, errors=["admin-ch"])
+    summary = run_harvest("t", root, github=github, now="2026-06-05T00:00:00Z")
+
+    assert summary.orgs_failed == ["admin-ch"]
+    assert summary.repos_total == 0
+    org = _inventory(root)["organizations"][0]
+    assert org["repositories"] == []
+    assert org["harvested_at"] is None
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/admin-ch", "admin-ch"),
+        ("https://github.com/cdc-si/", "cdc-si"),
+        ("https://github.com/KOST-CECO", "KOST-CECO"),
+    ],
+)
+def test_org_login(url, expected):
+    assert org_login(url) == expected

--- a/tests/test_harvest_github.py
+++ b/tests/test_harvest_github.py
@@ -1,0 +1,98 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline tests for the GitHub GraphQL client (recorded fixtures only)."""
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from codeswissgov.harvest.github import GitHubClient, GitHubError
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _fixture(name: str) -> dict:
+    return json.loads((FIXTURES / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def _client() -> GitHubClient:
+    return GitHubClient(token="t0ken", client=httpx.Client())
+
+
+def test_fetch_single_page_maps_all_fields(httpx_mock):
+    httpx_mock.add_response(json=_fixture("graphql_org_single"))
+    repos = _client().fetch_org_repositories("admin-ch")
+
+    assert [r.name for r in repos] == ["open-tool", "legacy-archive"]
+
+    full = repos[0]
+    assert full.url == "https://github.com/admin-ch/open-tool"
+    assert full.license == "MIT"
+    assert full.language == "Python"
+    assert full.topics == ["government", "switzerland"]
+    assert full.archived is False
+    assert full.last_activity == "2026-01-15"  # date only, time dropped
+    assert full.has_publiccode_yml is True
+    assert full.has_security_md is True
+
+    bare = repos[1]
+    assert bare.license is None and bare.is_compliance_flag
+    assert bare.language is None
+    assert bare.topics == []
+    assert bare.archived is True
+    assert bare.last_activity is None
+    assert bare.has_publiccode_yml is False
+    assert bare.has_security_md is False
+
+
+def test_pagination_follows_cursor(httpx_mock):
+    httpx_mock.add_response(json=_fixture("graphql_org_page1"))
+    httpx_mock.add_response(json=_fixture("graphql_org_page2"))
+
+    repos = _client().fetch_org_repositories("admin-ch")
+    assert [r.name for r in repos] == ["alpha", "beta"]
+
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    first = json.loads(requests[0].read())
+    second = json.loads(requests[1].read())
+    assert first["variables"]["cursor"] is None
+    assert second["variables"]["cursor"] == "Y3Vyc29yOjE="  # page1 endCursor
+
+
+def test_sends_bearer_token(httpx_mock):
+    httpx_mock.add_response(json=_fixture("graphql_org_single"))
+    _client().fetch_org_repositories("admin-ch")
+    assert httpx_mock.get_requests()[0].headers["Authorization"] == "bearer t0ken"
+
+
+def test_unknown_org_raises(httpx_mock):
+    httpx_mock.add_response(json=_fixture("graphql_org_not_found"))
+    with pytest.raises(GitHubError, match="not found"):
+        _client().fetch_org_repositories("nope")
+
+
+def test_graphql_errors_raise(httpx_mock):
+    httpx_mock.add_response(json={"errors": [{"message": "Bad credentials"}]})
+    with pytest.raises(GitHubError, match="GraphQL errors"):
+        _client().fetch_org_repositories("admin-ch")
+
+
+def test_http_status_error_raises(httpx_mock):
+    httpx_mock.add_response(status_code=401, json={"message": "Unauthorized"})
+    with pytest.raises(GitHubError, match="request failed"):
+        _client().fetch_org_repositories("admin-ch")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for the Organization model."""
+"""Unit tests for the Organization and Repository models."""
 
 import pytest
 from pydantic import ValidationError
 
-from codeswissgov.models import Organization
+from codeswissgov.models import Organization, Repository
 
 
 def test_valid_federal_org():
@@ -95,3 +95,57 @@ def test_unknown_field_rejected():
             url="https://github.com/x",
             link_title="legacy field",
         )
+
+
+def test_repository_defaults():
+    repo = Repository(name="tool", url="https://github.com/swiss/tool")
+    assert repo.license is None
+    assert repo.language is None
+    assert repo.topics == []
+    assert repo.archived is False
+    assert repo.last_activity is None
+    assert repo.has_publiccode_yml is False
+    assert repo.has_security_md is False
+
+
+def test_repository_full_record():
+    repo = Repository(
+        name="tool",
+        url="https://github.com/swiss/tool",
+        license="MIT",
+        language="Python",
+        topics=["gov", "ch"],
+        archived=True,
+        last_activity="2026-01-15",
+        has_publiccode_yml=True,
+        has_security_md=True,
+    )
+    assert repo.license == "MIT"
+    assert repo.topics == ["gov", "ch"]
+    assert repo.archived is True
+
+
+def test_repository_missing_license_is_compliance_flag():
+    assert Repository(name="t", url="https://github.com/o/t").is_compliance_flag
+    licensed = Repository(name="t", url="https://github.com/o/t", license="Apache-2.0")
+    assert not licensed.is_compliance_flag
+
+
+def test_repository_name_is_stripped():
+    repo = Repository(name="  tool  ", url="https://github.com/o/tool")
+    assert repo.name == "tool"
+
+
+def test_repository_empty_name_rejected():
+    with pytest.raises(ValidationError, match="name must not be empty"):
+        Repository(name="   ", url="https://github.com/o/t")
+
+
+def test_repository_non_github_url_rejected():
+    with pytest.raises(ValidationError, match="github.com"):
+        Repository(name="t", url="https://gitlab.com/o/t")
+
+
+def test_repository_unknown_field_rejected():
+    with pytest.raises(ValidationError):
+        Repository(name="t", url="https://github.com/o/t", stars=5)

--- a/tests/test_render_inventory.py
+++ b/tests/test_render_inventory.py
@@ -16,8 +16,13 @@
 
 import json
 
-from codeswissgov.models import Organization
-from codeswissgov.render.inventory import SCHEMA_VERSION, render_inventory
+from codeswissgov.models import Organization, Repository
+from codeswissgov.render.inventory import (
+    SCHEMA_VERSION,
+    OrgHarvest,
+    load_harvest,
+    render_inventory,
+)
 
 
 def _org(name, authority, handle):
@@ -37,8 +42,56 @@ def test_inventory_shape_and_fields():
             "url": "https://github.com/admin-ch",
             "official": False,
             "provenance": None,
+            "harvested_at": None,
+            "repositories": [],
         }
     ]
+
+
+def test_inventory_merges_harvested_repos():
+    org = _org("Swiss Admin", "federal", "admin-ch")
+    repo = Repository(
+        name="tool", url="https://github.com/admin-ch/tool", license="MIT"
+    )
+    harvest = {
+        org.url: OrgHarvest(harvested_at="2026-06-05T00:00:00Z", repositories=[repo])
+    }
+    entry = json.loads(render_inventory([org], harvest))["organizations"][0]
+    assert entry["harvested_at"] == "2026-06-05T00:00:00Z"
+    assert entry["repositories"] == [
+        {
+            "name": "tool",
+            "url": "https://github.com/admin-ch/tool",
+            "license": "MIT",
+            "language": None,
+            "topics": [],
+            "archived": False,
+            "last_activity": None,
+            "has_publiccode_yml": False,
+            "has_security_md": False,
+        }
+    ]
+
+
+def test_load_harvest_round_trips_repo_data():
+    org = _org("Swiss Admin", "federal", "admin-ch")
+    repo = Repository(name="tool", url="https://github.com/admin-ch/tool")
+    harvest = {
+        org.url: OrgHarvest(harvested_at="2026-06-05T00:00:00Z", repositories=[repo])
+    }
+    text = render_inventory([org], harvest)
+    reloaded = load_harvest(text)
+    assert reloaded == harvest
+
+
+def test_load_harvest_ignores_org_level_fields_and_blank():
+    assert load_harvest("") == {}
+    assert load_harvest("   ") == {}
+    # Org-level fields present but no repos -> empty OrgHarvest, not dropped.
+    text = render_inventory([_org("Swiss Admin", "federal", "admin-ch")])
+    assert load_harvest(text) == {
+        "https://github.com/admin-ch": OrgHarvest(harvested_at=None, repositories=[])
+    }
 
 
 def test_inventory_has_trailing_newline_and_preserves_unicode():


### PR DESCRIPTION
Implements **SPEC Epic 2 — Enrichment harvester**: expand each curated org into its repositories and enrich `inventory.json` with repo-level data from the GitHub API. Built incrementally as 7 isolated, verified commits.

## Acceptance criteria (all met)
- [x] `harvest` expands each org into repos with **license, language, topics, last activity, archived, `publiccode.yml`/`SECURITY.md` presence** → generated `inventory.json` (v2.0, repos nested per org), not per-repo YAML (decision #7).
- [x] **GraphQL, incremental + cached**; read-only PAT lifts the rate limit (decision #4). `inventory.json` is itself the cache — a failed org keeps its prior repos rather than being dropped.
- [x] **Scheduled workflow** (`harvest.yml`) opens an auto-PR with refreshed `inventory.json` (human merges).

## Architecture
- `inventory.json` is the **single** committed carrier of repo-level data (decision #7). `harvest` is the only writer of repo data; `build` regenerates org-level fields while **preserving** repo blocks, so `build`/`validate` stay offline and deterministic. The CI gate (`validate`) is unchanged in spirit.
- Network I/O isolated in `harvest/github.py` (injected `httpx.Client`); tested offline against recorded GraphQL fixtures via `pytest-httpx`.

## Commits
| Commit | What |
|--------|------|
| `eecf810` | `httpx` + `pytest-httpx` deps (pinned) |
| `88c928a` | `Repository` model |
| `669f071` | `inventory.json` v2.0 + merge plumbing |
| `45c6718` | GitHub GraphQL harvest client |
| `54b4c15` | harvest orchestration + `harvest` CLI |
| `cfe75ec` | scheduled `harvest.yml` with auto-PR |
| `8f1db5b` | docs + SPEC Epic 2 ticked |

## Decisions made within the approved plan (please review)
- `last_activity` stored as **ISO date** (not full timestamp) to keep weekly harvest diffs quiet.
- `license` maps GitHub `spdxId` verbatim; `null` → `None` (compliance flag). `NOASSERTION` kept as-is (not treated as "no license").
- **Forks excluded** (`isFork: false`) as curation noise.
- Schema number bumped to **2.0** now; formal versioning/documentation of `inventory.json` is SPEC-scheduled for Epic 3.

## Operational note
The scheduled workflow needs a repo secret **`HARVEST_GITHUB_TOKEN`** (read-only fine-grained PAT) to run; documented in the workflow header.

## Verification
`ruff check .` + `ruff format --check .` clean · 65 tests pass · `python -m codeswissgov validate` green.