### PR TITLE
Epic 3 (trimmed): swiss/index ingest + docs split

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,205 @@
+# Development guide
+
+Technical documentation for `awesome-codeswissgov` — installation, commands,
+contributing, architecture, and testing.
+
+This guide is the practical "how to work with the repo" reference. For the
+*what* and *why*, see [`SPEC.md`](./SPEC.md) (the buildable contract) and
+[`DESIGN.md`](./DESIGN.md) (strategy and rationale).
+
+---
+
+## Architecture overview
+
+`data/orgs/*.yaml` is the **source of truth** — one curated file per
+organization. `README.md` (the federal + cantonal tables) and `inventory.json`
+are **generated views**, never edited by hand:
+
+```
+data/orgs/*.yaml ── build ──▶ README.md tables
+                          └─▶ inventory.json
+                 ── harvest ─▶ inventory.json (repo-level data)
+```
+
+Because the views are regenerated from `data/orgs/` every time, there is no
+manual two-way sync to drift and orphaned rows cannot occur. `validate` (the CI
+gate) fails if the committed views are out of date.
+
+## Project structure
+
+```
+src/codeswissgov/
+  __main__.py        → CLI dispatch (build | validate | harvest | ingest)
+  models.py          → pydantic models: Organization, Repository
+  loader.py          → load + validate data/orgs/*.yaml
+  build.py           → render_all / build / validate
+  cantons.py         → 26-canton code ⇄ display-name reference map
+  orgurl.py          → GitHub org-URL helpers (org_login, login_key)
+  render/
+    __init__.py      → deterministic ordering (federal / cantonal)
+    readme.py        → data/orgs → README tables (between markers)
+    inventory.py     → data/orgs (+ harvest) → inventory.json
+  harvest/
+    __init__.py      → run_harvest orchestration
+    github.py        → GitHub GraphQL client
+  ingest/
+    __init__.py      → run_ingest orchestration
+    registry.py      → Candidate model, RegistrySource, reconcile, render_report
+    swiss_index.py   → swiss/index registry source
+data/orgs/*.yaml     → SOURCE OF TRUTH (curated, git-tracked)
+tests/               → pytest unit + fixture-based tests
+  fixtures/          → recorded API / registry responses
+.github/workflows/
+  ci.yml             → lint + test + validate (sync gate) on PR/push
+  harvest.yml        → scheduled harvest + auto-PR
+README.md            → GENERATED VIEW (do not hand-edit the tables)
+inventory.json       → GENERATED data product
+SPEC.md  DESIGN.md   → contract + rationale
+```
+
+## Installation
+
+Python 3.11+.
+
+```sh
+pip install -e . -r requirements-dev.txt
+```
+
+Runtime deps (`requirements.txt`): `PyYAML`, `httpx`, `pydantic` v2.
+Dev deps (`requirements-dev.txt`): `pytest`, `pytest-httpx`, `ruff`.
+
+## Commands
+
+All commands run as `python -m codeswissgov <command>`.
+
+| Command | Purpose |
+|---------|---------|
+| `build` | Regenerate `README.md` tables + `inventory.json` from `data/orgs/`. |
+| `validate` | Schema-check `data/orgs/` **and** assert the generated views are up to date (the CI gate). |
+| `harvest` | Enrich `inventory.json` with repo-level data from the GitHub API. |
+| `ingest` | Reconcile sibling registries (`swiss/index`) against `data/orgs/`; print a read-only report. |
+
+```sh
+python -m codeswissgov build
+python -m codeswissgov validate
+python -m codeswissgov harvest --token "$GITHUB_TOKEN"   # or $GITHUB_TOKEN in env
+python -m codeswissgov ingest                            # no token needed
+```
+
+## Contributing
+
+To add or update an organization:
+
+1. Add or edit a file under `data/orgs/`, named after the GitHub handle, e.g.
+   `data/orgs/<github-handle>.yaml`:
+   ```yaml
+   name: Statistics I            # display name (service for federal; unit for cantonal)
+   authority: canton:ZH          # "federal" or "canton:<CODE>" (e.g. canton:BE)
+   url: https://github.com/statistikstadtzuerich
+   official: false               # true only with recorded provenance (see below)
+   provenance: null              # evidence source backing `official`
+   ```
+   A canton with no known GitHub org needs **no** file — the build renders
+   `— none known yet` for it automatically.
+2. Regenerate the views:
+   ```sh
+   pip install -e .
+   python -m codeswissgov build
+   ```
+   The build is deterministic and self-cleaning (orphan rows cannot occur —
+   the tables are rebuilt from `data/orgs/` every time).
+3. Commit the `data/orgs/` change **and** the regenerated `README.md` and
+   `inventory.json`.
+
+## Data model & schema
+
+**`Organization`** (curated, in `data/orgs/*.yaml`):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | str | Display name (service for federal; unit for cantonal). |
+| `authority` | str | `"federal"` or `"canton:<CODE>"` (e.g. `canton:ZH`). |
+| `url` | str | GitHub organization URL (only GitHub is in scope). |
+| `official` | bool | Verified-official flag; defaults `false`. |
+| `provenance` | str \| null | Evidence backing `official`. |
+
+`official: true` is only permitted with a non-empty `provenance` (a registry
+listing, a GitHub verified-domain match, or explicit confirmation); otherwise
+the entry is an unverified candidate.
+
+**`Repository`** (harvested, in `inventory.json` only — never in `data/orgs`):
+`name`, `url`, `license` (SPDX id; `null` = compliance flag), `language`,
+`topics`, `archived`, `last_activity` (ISO-8601 date), `has_publiccode_yml`,
+`has_security_md`.
+
+**`inventory.json`** (`schema_version: "2.0"`): an `organizations` array; each
+entry carries the org fields plus `harvested_at` and a nested `repositories`
+array. Output is canonical (stable order, two-space indent, trailing newline,
+non-ASCII preserved) so diffs stay clean.
+
+## Repository-level data (harvest)
+
+`inventory.json` carries harvested repo-level data per organization. It is
+produced from the GitHub **GraphQL** API with a read-only fine-grained PAT (to
+lift the rate limit); the harvest is incremental and **cache-backed** —
+`inventory.json` is itself the cache, so an org whose fetch fails keeps its
+prior repositories rather than being dropped.
+
+```sh
+python -m codeswissgov harvest --token "$GITHUB_TOKEN"
+```
+
+`harvest` is the only writer of repo-level data; `build` preserves it when it
+regenerates the views.
+
+## Ecosystem interop (ingest)
+
+The federal org list is meant to track the upstream
+[`swiss/index`](https://github.com/swiss/index) registry. `ingest` reconciles
+that registry (via a pluggable `RegistrySource` framework) against `data/orgs/`
+and prints a **read-only** report — it never edits `data/orgs/`:
+
+```sh
+python -m codeswissgov ingest        # no token needed (public registry)
+```
+
+The report lists orgs present in a registry but **missing** from `data/orgs/`
+(the coverage gap to review), with a federal/cantonal hint from the registry's
+section. It is guidance only: a maintainer decides what to add and creates the
+YAML file by hand (with provenance), so curation stays human. Non-GitHub forges
+(e.g. GitLab entries in `swiss/index`) are reported as skipped.
+
+## Testing & linting
+
+```sh
+ruff check . && ruff format --check .                       # lint + format check
+ruff format .                                               # apply formatting
+pytest                                                      # run tests
+pytest --cov=codeswissgov --cov-report=term-missing         # with coverage
+```
+
+Tests run **offline**: harvest and ingest network clients are tested against
+recorded fixtures (`pytest-httpx`) under `tests/fixtures/`, never the live API.
+`ruff` governs lint and format (line length 88).
+
+## CI & automation
+
+- **`ci.yml`** (PR/push): runs `ruff`, `pytest`, and `python -m codeswissgov
+  validate`, failing on a lint error, a test failure, **or** any drift between
+  `data/orgs/` and the generated views.
+- **`harvest.yml`** (scheduled, Mondays 04:00 UTC + manual dispatch): runs
+  `harvest`, rebuilds the views, and opens an auto-PR with the refreshed
+  `inventory.json` for a human to merge. Requires a `HARVEST_GITHUB_TOKEN`
+  repository secret (read-only fine-grained PAT).
+
+## Scope & non-goals
+
+- **GitHub only.** GitLab (incl. self-hosted / openCoDE), Bitbucket and other
+  forges are out of scope. Coverage means "present on GitHub", **not**
+  "publishes open source" — so absence is not evidence that an authority
+  publishes nothing.
+- **Federal + cantonal only.** Municipal authorities (~2,000 communes) are out
+  of scope as a coverage goal.
+
+Both are deliberate trade-offs; expanding either is an "ask first" scope change
+(see `SPEC.md`).

--- a/README.md
+++ b/README.md
@@ -78,75 +78,21 @@ Zürich|[Transport](https://github.com/VerkehrsbetriebeZuerich)
 
 <!-- END CANTONAL LIST -->
 
-## Contributing
+## About this list
 
-`data/orgs/*.yaml` is the **source of truth** — one file per organization. The
-tables above and `inventory.json` are **generated views**; never edit them or
-the rows by hand (a build will overwrite your changes).
+The tables above are **generated** from `data/orgs/*.yaml` (the source of
+truth) — don't edit the rows by hand. Coverage is **GitHub only**: authorities
+that publish solely off GitHub do not appear here, so absence is not evidence
+that an authority publishes nothing.
 
-To add or update an organization:
+## Contributing & development
 
-1. Add or edit a file under `data/orgs/`, e.g. `data/orgs/<github-handle>.yaml`:
-   ```yaml
-   name: Statistics I            # display name (service for federal; unit for cantonal)
-   authority: canton:ZH          # "federal" or "canton:<CODE>" (e.g. canton:BE)
-   url: https://github.com/statistikstadtzuerich
-   official: false               # true only with recorded provenance (see below)
-   provenance: null              # evidence source backing `official`
-   ```
-   A canton with no known GitHub org needs **no** file — the build renders
-   `— none known yet` for it automatically.
-2. Regenerate the views:
-   ```sh
-   pip install -e .
-   python -m codeswissgov build
-   ```
-   The build is deterministic and self-cleaning (orphan rows cannot occur —
-   the tables are rebuilt from `data/orgs/` every time).
-3. Commit the `data/orgs/` change **and** the regenerated `README.md` and
-   `inventory.json`.
+To add or update an organization, edit `data/orgs/` and regenerate the views.
+Full instructions — installation, commands, the data model, harvesting, and
+testing — are in **[DEVELOPMENT.md](./DEVELOPMENT.md)**.
 
-`official: true` is only permitted with a non-empty `provenance` (a registry
-listing, a GitHub verified-domain match, or explicit confirmation); otherwise
-the entry is an unverified candidate.
-
-Development tooling: `pip install -r requirements-dev.txt` then `ruff check .`
-and `pytest`. CI runs lint, tests, and `python -m codeswissgov validate`, which
-fails if `data/orgs/` is invalid or the generated views are out of date.
-
-### Repository-level data (harvest)
-
-`inventory.json` also carries **harvested** repo-level data per organization
-(license, language, topics, last activity, archived state, and `publiccode.yml`
-/ `SECURITY.md` presence). This is produced from the GitHub API — you do not
-edit it by hand:
-
-```sh
-python -m codeswissgov harvest --token "$GITHUB_TOKEN"   # read-only PAT
-```
-
-`harvest` is the only writer of repo-level data; `build` preserves it when it
-regenerates the views. A scheduled workflow refreshes it weekly and opens a PR.
-Coverage is **GitHub only** — authorities that publish solely off GitHub do not
-appear, so absence is not evidence that an authority publishes nothing.
-
-### Ecosystem interop (ingest)
-
-The federal org list is meant to track the upstream
-[`swiss/index`](https://github.com/swiss/index) registry. `ingest` reconciles
-that registry (and any future sibling registries) against `data/orgs` and
-prints a **read-only** report — it never edits `data/orgs`:
-
-```sh
-python -m codeswissgov ingest        # no token needed (public registry)
-```
-
-The report lists orgs present in a registry but **missing** from `data/orgs`
-(the coverage gap to review), with a federal/cantonal hint from the registry's
-section. It is guidance only: a maintainer decides what to add and creates the
-`data/orgs/*.yaml` file by hand (with provenance), so curation stays human.
-Non-GitHub forges (e.g. GitLab entries in `swiss/index`) are reported as
-skipped — coverage is **GitHub only**.
+See also [`SPEC.md`](./SPEC.md) (the buildable contract) and
+[`DESIGN.md`](./DESIGN.md) (strategy and rationale).
 
 ## License 
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ regenerates the views. A scheduled workflow refreshes it weekly and opens a PR.
 Coverage is **GitHub only** — authorities that publish solely off GitHub do not
 appear, so absence is not evidence that an authority publishes nothing.
 
+### Ecosystem interop (ingest)
+
+The federal org list is meant to track the upstream
+[`swiss/index`](https://github.com/swiss/index) registry. `ingest` reconciles
+that registry (and any future sibling registries) against `data/orgs` and
+prints a **read-only** report — it never edits `data/orgs`:
+
+```sh
+python -m codeswissgov ingest        # no token needed (public registry)
+```
+
+The report lists orgs present in a registry but **missing** from `data/orgs`
+(the coverage gap to review), with a federal/cantonal hint from the registry's
+section. It is guidance only: a maintainer decides what to add and creates the
+`data/orgs/*.yaml` file by hand (with provenance), so curation stays human.
+Non-GitHub forges (e.g. GitLab entries in `swiss/index`) are reported as
+skipped — coverage is **GitHub only**.
+
 ## License 
 
 This repository assets, content and data folders are licensed under a [CC-BY license](./LICENSE). 

--- a/SPEC.md
+++ b/SPEC.md
@@ -231,11 +231,19 @@ Fold in the audit backlog so the tool is solid before the refactor.
 - [x] Scheduled workflow (`harvest.yml`) opens an auto-PR with refreshed
       `inventory.json` (human merges).
 
-### Epic 3 — Ecosystem interop
-- [ ] Ingest `swiss/index` programmatically as the **federal source**, plus ≥1
-      sibling registry to seed coverage (decision #1: superset + enrichment).
-- [ ] `inventory.json` documented & versioned; emit/consume `publiccode.yml`
-      for EU-ecosystem interop.
+### Epic 3 — Ecosystem interop (trimmed — see decision #10)
+- [x] Ingest `swiss/index` programmatically as the **federal source** (decision
+      #1: superset + enrichment). `python -m codeswissgov ingest` reconciles the
+      registry against `data/orgs` via a pluggable `RegistrySource` framework
+      and prints a **read-only** coverage-gap report (never auto-adds); against
+      live `swiss/index` it surfaces 24 missing federal orgs + the GitHub-only
+      skipped count.
+- [ ] ~~plus ≥1 sibling registry to seed coverage~~ — **deferred** (decision
+      #10): no foreign registry seeds *Swiss* coverage; the framework is
+      pluggable so a real Swiss second source (e.g. opendata.swiss) slots in
+      later.
+- [ ] ~~`inventory.json` documented & versioned; emit/consume `publiccode.yml`~~
+      — **deferred** (decision #10): speculative until a consumer exists.
 
 ### Epic 4 — Data integrity
 - [ ] Link-rot detection flags 404 / renamed / deleted orgs.
@@ -292,6 +300,19 @@ Fold in the audit backlog so the tool is solid before the refactor.
    constant `Link`. Harvested fields (license/language/topics/activity/…) are
    **not** in the org YAML — they land in `inventory.json` in Epic 2. In Epic 1,
    `inventory.json` is **org-level only**.
+10. **Epic 3 trimmed to the swiss/index ingest; rest deferred as YAGNI.** A live
+    diff showed the manual swiss/index sync had drifted (24 federal orgs missing
+    from `data/orgs`), so ingesting it is load-bearing and shipped: a pluggable
+    `RegistrySource` framework producing a **read-only** reconciliation report
+    (consistent with the "never auto-add" / "ask-first on data changes"
+    boundaries). The other Epic 3 criteria — a **≥1 sibling registry**, a formal
+    **`inventory.json` JSON Schema**, and **`publiccode.yml` emit/consume** —
+    are **deferred** because they have no current consumer: no *foreign*
+    registry seeds *Swiss* coverage (their entries filter out as non-Swiss), and
+    emitting/schematizing for an absent consumer is speculative. The framework
+    stays pluggable so each slots in when a real need appears (e.g. a Swiss
+    second source like opendata.swiss). Re-expanding Epic 3 is a normal
+    backlog decision, not an "ask-first" scope change.
 
 ---
 

--- a/src/codeswissgov/__main__.py
+++ b/src/codeswissgov/__main__.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CLI entry point: ``python -m codeswissgov <build|validate|harvest>``.
+"""CLI entry point: ``python -m codeswissgov <build|validate|harvest|ingest>``.
 
 ``build``    regenerate README.md + inventory.json from data/orgs.
 ``validate`` schema-check data/orgs and assert the generated views are current.
 ``harvest``  enrich inventory.json with repo-level data from the GitHub API.
+``ingest``   reconcile sibling registries (swiss/index) against data/orgs.
 """
 
 import os
@@ -24,8 +25,10 @@ import sys
 
 from .build import build, validate
 from .harvest import run_harvest
+from .ingest import run_ingest
+from .ingest.registry import IngestError, render_report
 
-USAGE = "usage: python -m codeswissgov <build|validate|harvest [--token TOKEN]>"
+USAGE = "usage: python -m codeswissgov <build|validate|harvest [--token TOKEN]|ingest>"
 
 
 def _cmd_build(args: list[str]) -> int:
@@ -75,6 +78,21 @@ def _cmd_harvest(args: list[str]) -> int:
     return 1 if summary.orgs_failed and summary.orgs_refreshed == 0 else 0
 
 
+def _cmd_ingest(args: list[str]) -> int:
+    """Reconcile registries against data/orgs and print a read-only report.
+
+    Tokenless (the registry README is a public raw file) and never mutates
+    data/orgs — it only surfaces the coverage gap for a human to curate.
+    """
+    try:
+        report = run_ingest()
+    except IngestError as exc:
+        print(f"ingest: {exc}", file=sys.stderr)
+        return 1
+    print(render_report(report), end="")
+    return 0
+
+
 def _token(args: list[str]) -> str | None:
     """Resolve a token from ``--token VALUE``/``--token=VALUE`` or env."""
     for i, arg in enumerate(args):
@@ -85,7 +103,12 @@ def _token(args: list[str]) -> str | None:
     return os.environ.get("GITHUB_TOKEN")
 
 
-COMMANDS = {"build": _cmd_build, "validate": _cmd_validate, "harvest": _cmd_harvest}
+COMMANDS = {
+    "build": _cmd_build,
+    "validate": _cmd_validate,
+    "harvest": _cmd_harvest,
+    "ingest": _cmd_ingest,
+}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/codeswissgov/harvest/__init__.py
+++ b/src/codeswissgov/harvest/__init__.py
@@ -33,8 +33,11 @@ import httpx
 
 from ..build import DEFAULT_ROOT
 from ..loader import load_organizations
+from ..orgurl import org_login
 from ..render.inventory import OrgHarvest, load_harvest, render_inventory
 from .github import GitHubClient, GitHubError
+
+__all__ = ["HarvestSummary", "org_login", "run_harvest"]
 
 
 @dataclass(frozen=True)
@@ -45,15 +48,6 @@ class HarvestSummary:
     orgs_refreshed: int
     repos_total: int
     orgs_failed: list[str] = field(default_factory=list)
-
-
-def org_login(url: str) -> str:
-    """Extract the GitHub org login from an organization URL.
-
-    ``https://github.com/admin-ch`` and ``.../cdc-si/`` both -> the last
-    path segment, tolerating a trailing slash.
-    """
-    return url.rstrip("/").rsplit("/", 1)[-1]
 
 
 def _utc_now() -> str:

--- a/src/codeswissgov/ingest/__init__.py
+++ b/src/codeswissgov/ingest/__init__.py
@@ -1,0 +1,23 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry ingestion: reconcile sibling registries against ``data/orgs``.
+
+Epic 3 closes a live drift: the org list is meant to be synced from the federal
+``github.com/swiss/index`` registry, but that sync is manual and has fallen
+behind. This package ingests such registries and emits a **read-only**
+reconciliation report — it never mutates ``data/orgs`` (a human reviews the
+report and curates). The :class:`RegistrySource` protocol keeps it pluggable so
+further sources slot in without touching the reconciliation core.
+"""

--- a/src/codeswissgov/ingest/__init__.py
+++ b/src/codeswissgov/ingest/__init__.py
@@ -21,3 +21,47 @@ reconciliation report — it never mutates ``data/orgs`` (a human reviews the
 report and curates). The :class:`RegistrySource` protocol keeps it pluggable so
 further sources slot in without touching the reconciliation core.
 """
+
+from pathlib import Path
+
+import httpx
+
+from ..build import DEFAULT_ROOT
+from ..loader import load_organizations
+from .registry import ReconciliationReport, RegistrySource, reconcile
+from .swiss_index import SwissIndexSource
+
+# The registries ingested by default. swiss/index is the federal source
+# (SPEC decision #1); the list is the single place to register more sources.
+SOURCES: list[RegistrySource] = [SwissIndexSource()]
+
+
+def run_ingest(
+    root: Path = DEFAULT_ROOT,
+    *,
+    sources: list[RegistrySource] | None = None,
+    client: httpx.Client | None = None,
+) -> ReconciliationReport:
+    """Fetch every registry source and reconcile it against ``data/orgs``.
+
+    Args:
+        root: Repository root containing ``data/orgs``.
+        sources: Registries to ingest; defaults to :data:`SOURCES`.
+        client: Injected ``httpx.Client`` (tests); a default one is created and
+            closed here when omitted.
+
+    Returns:
+        A read-only :class:`ReconciliationReport`. Nothing is written to disk.
+    """
+    sources = SOURCES if sources is None else sources
+    orgs = load_organizations(root / "data" / "orgs")
+
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    try:
+        results = [source.fetch(client) for source in sources]
+    finally:
+        if owns_client:
+            client.close()
+
+    return reconcile(results, orgs)

--- a/src/codeswissgov/ingest/registry.py
+++ b/src/codeswissgov/ingest/registry.py
@@ -36,6 +36,10 @@ FEDERAL_HINT = "federal"
 CANTONAL_HINT = "cantonal"
 
 
+class IngestError(RuntimeError):
+    """A registry could not be fetched or parsed."""
+
+
 class Candidate(BaseModel):
     """A GitHub org URL surfaced by a registry, with its provenance.
 

--- a/src/codeswissgov/ingest/registry.py
+++ b/src/codeswissgov/ingest/registry.py
@@ -1,0 +1,183 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry candidates, the source protocol, and pure reconciliation.
+
+A :class:`RegistrySource` fetches :class:`Candidate` org URLs from one external
+registry. :func:`reconcile` compares those candidates against the curated
+``data/orgs`` and classifies each as missing / matched / extra; nothing here
+touches the filesystem or the network, so it is fully unit-testable offline.
+"""
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+import httpx
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from ..models import Organization
+from ..orgurl import login_key
+
+# Shared with the org/repo models: only GitHub is in scope (SPEC non-goal).
+_GITHUB_PREFIX = "https://github.com/"
+
+FEDERAL_HINT = "federal"
+CANTONAL_HINT = "cantonal"
+
+
+class Candidate(BaseModel):
+    """A GitHub org URL surfaced by a registry, with its provenance.
+
+    Attributes:
+        url: GitHub organization URL (only GitHub is in scope).
+        source: Registry that listed it, e.g. ``"swiss/index"``.
+        section: The registry's own section/heading the entry sat under, kept
+            as a provenance hint (``None`` if the registry is flat).
+        authority_hint: Coarse authority guess derived from ``section``
+            (``"federal"`` / ``"cantonal"``), or ``None``. A hint only — the
+            curator sets the real ``authority`` when adding the org.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str
+    source: str
+    section: str | None = None
+    authority_hint: str | None = None
+
+    @field_validator("url")
+    @classmethod
+    def _url_is_github(cls, value: str) -> str:
+        if not value.startswith(_GITHUB_PREFIX):
+            raise ValueError(f"url must be a {_GITHUB_PREFIX} URL, got {value!r}")
+        return value
+
+
+@dataclass(frozen=True)
+class SourceResult:
+    """One registry's fetch outcome.
+
+    ``skipped`` carries entries dropped because they are out of scope (non-GitHub
+    forges such as GitLab), so the report can state the GitHub-only under-count
+    explicitly rather than hiding it (SPEC coverage-reporting requirement).
+    """
+
+    name: str
+    candidates: list[Candidate] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+
+
+@runtime_checkable
+class RegistrySource(Protocol):
+    """A pluggable external registry that yields GitHub org candidates."""
+
+    name: str
+
+    def fetch(self, client: httpx.Client) -> SourceResult:
+        """Fetch and parse this registry into a :class:`SourceResult`."""
+        ...
+
+
+@dataclass(frozen=True)
+class ReconciliationReport:
+    """The read-only outcome of reconciling registries against ``data/orgs``.
+
+    Attributes:
+        missing: Candidates whose login is absent from ``data/orgs`` — the
+            actionable coverage gap a curator should review.
+        matched: Candidates already present in ``data/orgs``.
+        extra: Curated orgs not listed by any ingested registry (mostly our
+            cantonal breadth, since the federal registry omits it) — expected,
+            not an error.
+        sources: Names of the registries that were ingested.
+        skipped: Out-of-scope (non-GitHub) URLs dropped across all sources.
+    """
+
+    missing: list[Candidate]
+    matched: list[Candidate]
+    extra: list[Organization]
+    sources: list[str]
+    skipped: list[str]
+
+
+def reconcile(
+    results: list[SourceResult], orgs: list[Organization]
+) -> ReconciliationReport:
+    """Classify registry candidates against the curated ``orgs``.
+
+    Matching is case-insensitive on the GitHub login (:func:`login_key`), since
+    GitHub treats logins case-insensitively. Candidates are de-duplicated by
+    login (a registry may list the same org with/without a trailing slash, or
+    two registries may overlap), keeping the first occurrence.
+    """
+    known = {login_key(o.url) for o in orgs}
+
+    missing: list[Candidate] = []
+    matched: list[Candidate] = []
+    seen: set[str] = set()
+    candidate_keys: set[str] = set()
+    for result in results:
+        for candidate in result.candidates:
+            key = login_key(candidate.url)
+            candidate_keys.add(key)
+            if key in seen:
+                continue
+            seen.add(key)
+            (matched if key in known else missing).append(candidate)
+
+    extra = [o for o in orgs if login_key(o.url) not in candidate_keys]
+    skipped = [url for result in results for url in result.skipped]
+    return ReconciliationReport(
+        missing=missing,
+        matched=matched,
+        extra=extra,
+        sources=[r.name for r in results],
+        skipped=skipped,
+    )
+
+
+def render_report(report: ReconciliationReport) -> str:
+    """Render a reconciliation report as human-readable markdown.
+
+    Output is read-only guidance: the ``missing`` section lists orgs a curator
+    should consider adding to ``data/orgs`` (with the registry's authority hint
+    and provenance), never an instruction to auto-add.
+    """
+    sources = ", ".join(report.sources) or "(none)"
+    lines = [
+        "# Registry reconciliation report",
+        "",
+        f"Sources ingested: {sources}",
+        "",
+        f"- {len(report.missing)} in a registry but **missing** from data/orgs",
+        f"- {len(report.matched)} already covered",
+        f"- {len(report.extra)} in data/orgs but not in any registry "
+        "(mostly cantonal breadth; expected)",
+        f"- {len(report.skipped)} non-GitHub entries skipped (GitHub-only)",
+        "",
+        "## Missing from data/orgs (review and curate — never auto-added)",
+        "",
+    ]
+    if report.missing:
+        for candidate in report.missing:
+            hint = candidate.authority_hint or "?"
+            lines.append(f"- {candidate.url} — hint: {hint} (via {candidate.source})")
+    else:
+        lines.append("- (none)")
+
+    if report.skipped:
+        lines += ["", "## Skipped (non-GitHub, out of scope)", ""]
+        lines += [f"- {url}" for url in report.skipped]
+
+    return "\n".join(lines) + "\n"

--- a/src/codeswissgov/ingest/swiss_index.py
+++ b/src/codeswissgov/ingest/swiss_index.py
@@ -1,0 +1,113 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The ``swiss/index`` registry source: the federal index of GitHub orgs.
+
+``swiss/index`` is a plain markdown README — sectioned ``## headings`` with one
+``* <url>`` bullet per organization. Network I/O (:func:`fetch_readme`) is kept
+separate from the pure :func:`parse_index`, so parsing is tested offline against
+a recorded fixture. Only GitHub orgs are in scope (SPEC non-goal): GitLab and
+other forges are recorded as ``skipped`` so the GitHub-only under-count is
+stated, not hidden.
+"""
+
+import re
+from dataclasses import dataclass
+
+import httpx
+
+from .registry import (
+    CANTONAL_HINT,
+    FEDERAL_HINT,
+    Candidate,
+    IngestError,
+    SourceResult,
+)
+
+SOURCE_NAME = "swiss/index"
+# HEAD resolves the default branch, so we are not pinned to "main" vs "master".
+SWISS_INDEX_URL = "https://raw.githubusercontent.com/swiss/index/HEAD/README.md"
+
+_GITHUB_PREFIX = "https://github.com/"
+_SECTION_RE = re.compile(r"^#+\s+(.*\S)\s*$")
+# First http(s) URL on a bullet line; stop at whitespace or markdown delimiters.
+_URL_RE = re.compile(r"https?://[^\s)>\]]+")
+
+
+def fetch_readme(client: httpx.Client, url: str = SWISS_INDEX_URL) -> str:
+    """Fetch the raw ``swiss/index`` README. No token needed (public raw file).
+
+    Raises:
+        IngestError: the request failed or returned a non-2xx status.
+    """
+    try:
+        response = client.get(
+            url, headers={"User-Agent": "awesome-codeswissgov-ingest"}
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise IngestError(f"failed to fetch {url}: {exc}") from exc
+    return response.text
+
+
+def _authority_hint(section: str | None) -> str | None:
+    """Map a section heading to a coarse authority hint (a guess, not truth)."""
+    if section is None:
+        return None
+    return CANTONAL_HINT if "cantonal" in section.casefold() else FEDERAL_HINT
+
+
+def parse_index(markdown: str, source: str = SOURCE_NAME) -> SourceResult:
+    """Parse a ``swiss/index``-style README into a :class:`SourceResult`.
+
+    Walks the document tracking the current ``## section``; each bulleted URL
+    becomes a GitHub :class:`Candidate` (with the section as a provenance hint)
+    or, if it points at another forge, is recorded in ``skipped``.
+    """
+    candidates: list[Candidate] = []
+    skipped: list[str] = []
+    section: str | None = None
+    for line in markdown.splitlines():
+        heading = _SECTION_RE.match(line)
+        if heading:
+            section = heading.group(1)
+            continue
+        match = _URL_RE.search(line)
+        if not match:
+            continue
+        url = match.group(0)
+        if url.startswith(_GITHUB_PREFIX):
+            candidates.append(
+                Candidate(
+                    url=url,
+                    source=source,
+                    section=section,
+                    authority_hint=_authority_hint(section),
+                )
+            )
+        else:
+            skipped.append(url)
+    return SourceResult(name=source, candidates=candidates, skipped=skipped)
+
+
+@dataclass
+class SwissIndexSource:
+    """The federal ``swiss/index`` registry as a :class:`RegistrySource`."""
+
+    name: str = SOURCE_NAME
+    url: str = SWISS_INDEX_URL
+
+    def fetch(self, client: httpx.Client) -> SourceResult:
+        """Fetch and parse ``swiss/index`` into a :class:`SourceResult`."""
+        return parse_index(fetch_readme(client, self.url), source=self.name)

--- a/src/codeswissgov/orgurl.py
+++ b/src/codeswissgov/orgurl.py
@@ -1,0 +1,36 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for GitHub organization URLs, shared by harvest and ingest."""
+
+
+def org_login(url: str) -> str:
+    """Extract the GitHub org login from an organization URL.
+
+    ``https://github.com/admin-ch`` and ``.../cdc-si/`` both -> the last
+    path segment, tolerating a trailing slash. Case is preserved (the GitHub
+    API and display both want the real-case login); use :func:`login_key` when
+    comparing logins, since GitHub treats them case-insensitively.
+    """
+    return url.rstrip("/").rsplit("/", 1)[-1]
+
+
+def login_key(url: str) -> str:
+    """Case-insensitive match key for an org URL's login.
+
+    GitHub logins are case-insensitive, so reconciling two registries (e.g.
+    ``KOST-CECO`` vs ``kost-ceco``) must compare on a folded key, not the raw
+    login.
+    """
+    return org_login(url).casefold()

--- a/tests/fixtures/swiss_index_readme.md
+++ b/tests/fixtures/swiss_index_readme.md
@@ -1,0 +1,19 @@
+# Federal Open Source GitHub Index
+An overview of the current GitHub organisations maintained by the Swiss Confederation. This list is not exhaustive.
+
+## GitHub Organizations with Federal Ownership or Involvement
+* https://github.com/admin-ch
+* https://github.com/cdc-si/
+* https://github.com/KOST-CECO
+* https://github.com/govcert-ch
+
+## GitLab Organizations of Federal Organisations
+* https://gitlab.com/swiss-armed-forces
+
+## GitHub Organization of Federal Projects
+* https://github.com/visualize-admin
+* https://gitlabext.wsl.ch/safe
+* https://github.com/swisscovid
+
+## GitHub Organizations with Cantonal Ownership or Involvement
+* https://github.com/DCC-BS

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,3 +156,34 @@ def _summary(*, refreshed, failed=None):
         repos_total=refreshed,
         orgs_failed=failed,
     )
+
+
+# --- ingest command ---------------------------------------------------------
+
+
+def test_ingest_prints_report_and_succeeds(monkeypatch, capsys):
+    from codeswissgov.ingest.registry import Candidate, ReconciliationReport
+
+    report = ReconciliationReport(
+        missing=[Candidate(url="https://github.com/govcert-ch", source="swiss/index")],
+        matched=[],
+        extra=[],
+        sources=["swiss/index"],
+        skipped=[],
+    )
+    monkeypatch.setattr(cli, "run_ingest", lambda: report)
+    assert cli.main(["ingest"]) == 0
+    out = capsys.readouterr().out
+    assert "Registry reconciliation report" in out
+    assert "https://github.com/govcert-ch" in out
+
+
+def test_ingest_reports_fetch_error(monkeypatch, capsys):
+    from codeswissgov.ingest.registry import IngestError
+
+    def boom():
+        raise IngestError("failed to fetch swiss/index")
+
+    monkeypatch.setattr(cli, "run_ingest", boom)
+    assert cli.main(["ingest"]) == 1
+    assert "failed to fetch" in capsys.readouterr().err

--- a/tests/test_ingest_registry.py
+++ b/tests/test_ingest_registry.py
@@ -1,0 +1,124 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for registry candidates and pure reconciliation."""
+
+import pytest
+
+from codeswissgov.ingest.registry import (
+    Candidate,
+    ReconciliationReport,
+    SourceResult,
+    reconcile,
+    render_report,
+)
+from codeswissgov.models import Organization
+
+
+def _org(url: str, authority: str = "federal") -> Organization:
+    return Organization(name="x", authority=authority, url=url)
+
+
+def _cand(url: str, **kw) -> Candidate:
+    return Candidate(url=url, source=kw.pop("source", "swiss/index"), **kw)
+
+
+def test_candidate_rejects_non_github_url():
+    with pytest.raises(ValueError, match="github.com"):
+        _cand("https://gitlab.com/foo")
+
+
+def test_reconcile_classifies_missing_matched_extra():
+    orgs = [
+        _org("https://github.com/admin-ch"),
+        _org("https://github.com/canton-zh", "canton:ZH"),
+    ]
+    result = SourceResult(
+        name="swiss/index",
+        candidates=[
+            _cand("https://github.com/admin-ch"),  # matched
+            _cand("https://github.com/govcert-ch"),  # missing
+        ],
+    )
+    report = reconcile([result], orgs)
+
+    assert [c.url for c in report.missing] == ["https://github.com/govcert-ch"]
+    assert [c.url for c in report.matched] == ["https://github.com/admin-ch"]
+    # canton-zh is curated but absent from the federal registry -> extra.
+    assert [o.url for o in report.extra] == ["https://github.com/canton-zh"]
+    assert report.sources == ["swiss/index"]
+
+
+def test_reconcile_matches_case_insensitively_and_trailing_slash():
+    orgs = [_org("https://github.com/KOST-CECO")]
+    result = SourceResult(
+        name="swiss/index",
+        candidates=[
+            _cand("https://github.com/kost-ceco/"),  # same org, folded + slash
+            _cand("https://github.com/cdc-si/"),  # missing, trailing slash
+        ],
+    )
+    report = reconcile([result], orgs)
+
+    assert [c.url for c in report.matched] == ["https://github.com/kost-ceco/"]
+    assert [c.url for c in report.missing] == ["https://github.com/cdc-si/"]
+    assert report.extra == []
+
+
+def test_reconcile_dedupes_candidates_by_login():
+    result = SourceResult(
+        name="swiss/index",
+        candidates=[
+            _cand("https://github.com/govcert-ch"),
+            _cand("https://github.com/govcert-ch/"),  # duplicate by login
+        ],
+    )
+    report = reconcile([result], [])
+    assert [c.url for c in report.missing] == ["https://github.com/govcert-ch"]
+
+
+def test_reconcile_carries_skipped_non_github():
+    result = SourceResult(
+        name="swiss/index",
+        candidates=[],
+        skipped=["https://gitlab.com/swiss-armed-forces"],
+    )
+    report = reconcile([result], [])
+    assert report.skipped == ["https://gitlab.com/swiss-armed-forces"]
+
+
+def test_render_report_lists_missing_with_hint_and_counts():
+    report = ReconciliationReport(
+        missing=[_cand("https://github.com/govcert-ch", authority_hint="federal")],
+        matched=[],
+        extra=[],
+        sources=["swiss/index"],
+        skipped=["https://gitlab.com/x"],
+    )
+    text = render_report(report)
+
+    assert text.endswith("\n")
+    assert "Sources ingested: swiss/index" in text
+    assert "1 in a registry but **missing**" in text
+    assert "https://github.com/govcert-ch — hint: federal (via swiss/index)" in text
+    assert "1 non-GitHub entries skipped" in text
+    assert "https://gitlab.com/x" in text
+
+
+def test_render_report_handles_no_missing():
+    report = ReconciliationReport(
+        missing=[], matched=[], extra=[], sources=["swiss/index"], skipped=[]
+    )
+    text = render_report(report)
+    assert "- (none)" in text

--- a/tests/test_ingest_registry.py
+++ b/tests/test_ingest_registry.py
@@ -14,8 +14,10 @@
 
 """Unit tests for registry candidates and pure reconciliation."""
 
+import httpx
 import pytest
 
+from codeswissgov.ingest import run_ingest
 from codeswissgov.ingest.registry import (
     Candidate,
     ReconciliationReport,
@@ -23,6 +25,7 @@ from codeswissgov.ingest.registry import (
     reconcile,
     render_report,
 )
+from codeswissgov.loader import load_organizations
 from codeswissgov.models import Organization
 
 
@@ -122,3 +125,28 @@ def test_render_report_handles_no_missing():
     )
     text = render_report(report)
     assert "- (none)" in text
+
+
+class _FakeSource:
+    """A RegistrySource that returns a fixed result without any network."""
+
+    name = "fake"
+
+    def fetch(self, client: httpx.Client) -> SourceResult:
+        return SourceResult(
+            name=self.name,
+            candidates=[_cand("https://github.com/brand-new", source="fake")],
+            skipped=["https://gitlab.com/x"],
+        )
+
+
+def test_run_ingest_reconciles_real_data_orgs_offline(repo_root):
+    # Injected source + client => no network; reconciles against committed orgs.
+    report = run_ingest(repo_root, sources=[_FakeSource()], client=httpx.Client())
+    assert [c.url for c in report.missing] == ["https://github.com/brand-new"]
+    assert report.sources == ["fake"]
+    assert report.skipped == ["https://gitlab.com/x"]
+    # The committed orgs are absent from this fake source, so all land in
+    # `extra` and none match.
+    assert report.matched == []
+    assert len(report.extra) == len(load_organizations(repo_root / "data" / "orgs"))

--- a/tests/test_ingest_swiss_index.py
+++ b/tests/test_ingest_swiss_index.py
@@ -1,0 +1,94 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Offline tests for the swiss/index source (recorded fixture only)."""
+
+from pathlib import Path
+
+import httpx
+import pytest
+
+from codeswissgov.ingest.registry import CANTONAL_HINT, FEDERAL_HINT, IngestError
+from codeswissgov.ingest.swiss_index import (
+    SwissIndexSource,
+    fetch_readme,
+    parse_index,
+)
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "swiss_index_readme.md"
+
+
+def _readme() -> str:
+    return FIXTURE.read_text(encoding="utf-8")
+
+
+def test_parse_extracts_github_orgs_and_skips_other_forges():
+    result = parse_index(_readme())
+
+    assert [c.url for c in result.candidates] == [
+        "https://github.com/admin-ch",
+        "https://github.com/cdc-si/",
+        "https://github.com/KOST-CECO",
+        "https://github.com/govcert-ch",
+        "https://github.com/visualize-admin",
+        "https://github.com/swisscovid",
+        "https://github.com/DCC-BS",
+    ]
+    # GitLab + self-hosted GitLab are out of scope, recorded transparently.
+    assert result.skipped == [
+        "https://gitlab.com/swiss-armed-forces",
+        "https://gitlabext.wsl.ch/safe",
+    ]
+
+
+def test_parse_classifies_authority_hint_by_section():
+    by_url = {c.url: c for c in parse_index(_readme()).candidates}
+
+    # Both "Federal Ownership" and "Federal Projects" sections -> federal.
+    assert by_url["https://github.com/admin-ch"].authority_hint == FEDERAL_HINT
+    assert by_url["https://github.com/swisscovid"].authority_hint == FEDERAL_HINT
+    # The cantonal section -> cantonal.
+    assert by_url["https://github.com/DCC-BS"].authority_hint == CANTONAL_HINT
+
+
+def test_parse_records_section_and_source_as_provenance():
+    by_url = {c.url: c for c in parse_index(_readme()).candidates}
+    govcert = by_url["https://github.com/govcert-ch"]
+
+    assert govcert.source == "swiss/index"
+    assert "Federal Ownership" in govcert.section
+    assert parse_index(_readme()).name == "swiss/index"
+
+
+def test_fetch_readme_returns_body(httpx_mock):
+    httpx_mock.add_response(text="# index\n* https://github.com/admin-ch\n")
+    body = fetch_readme(httpx.Client(), url="https://example.test/README.md")
+    assert "github.com/admin-ch" in body
+
+
+def test_fetch_readme_raises_on_http_error(httpx_mock):
+    httpx_mock.add_response(status_code=404)
+    with pytest.raises(IngestError, match="failed to fetch"):
+        fetch_readme(httpx.Client(), url="https://example.test/missing.md")
+
+
+def test_source_fetch_end_to_end(httpx_mock):
+    httpx_mock.add_response(text=_readme())
+    result = SwissIndexSource(url="https://example.test/README.md").fetch(
+        httpx.Client()
+    )
+
+    assert result.name == "swiss/index"
+    assert len(result.candidates) == 7
+    assert len(result.skipped) == 2


### PR DESCRIPTION
## Summary

Implements **Epic 3 — Ecosystem Interop** (trimmed to its load-bearing piece, per SPEC decision #10) and reorganizes the project docs.

### Why trimmed
A live diff showed the manual `swiss/index` sync had drifted — **24 federal orgs in `swiss/index` are missing from `data/orgs`** (~50% gap). Closing that is real, measurable value. The other Epic 3 criteria (≥1 sibling registry, `inventory.json` JSON Schema, `publiccode.yml` emit/consume) are **deferred as YAGNI** — no current consumer; the `RegistrySource` framework is left pluggable so they slot in later. Recorded as SPEC decision #10.

## What's in this PR

**Registry ingest (`src/codeswissgov/ingest/`)**
- `registry.py` — `Candidate` model, pluggable `RegistrySource` protocol, pure `reconcile()` + `render_report()`.
- `swiss_index.py` — fetch (tokenless, HEAD-pinned) + pure markdown parse; skips non-GitHub forges.
- `run_ingest` orchestration + tokenless `ingest` CLI command (read-only — never mutates `data/orgs`).
- Shared `orgurl.py` (`org_login`, `login_key`) extracted from harvest.

**Docs**
- New `DEVELOPMENT.md` with all technical documentation (install, commands, data model, harvest, ingest, testing, CI, scope).
- `README.md` slimmed to the rendered org list + a minimal footer linking `DEVELOPMENT.md` / `SPEC.md` / `DESIGN.md`.
- `SPEC.md` Epic 3 status + decision #10.

## Verification
- `python -m codeswissgov ingest` against live `swiss/index` surfaces the 24 missing federal orgs + 2 skipped GitLab entries; `DCC-BS` hinted cantonal.
- `validate` green (no generated-view drift), `ruff` clean, **81 tests pass**, 97% coverage (tests fully offline via recorded fixtures).

## Notes for reviewers
- `ingest` is a manual tool, intentionally **not** wired into the CI `validate` gate.
- Next maintainer step: review the 24 missing orgs the report surfaces and add `data/orgs/*.yaml` for the legitimate ones.