### PR TITLE
feat: link-rot check, inventory reports, governance mechanics

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contribution & governance guide
+    url: https://github.com/ospo-ch/awesome-codeswissgov/blob/main/CONTRIBUTING.md
+    about: How suggestions are reviewed, the provenance policy, and how to edit data/orgs directly.
+  - name: Development guide
+    url: https://github.com/ospo-ch/awesome-codeswissgov/blob/main/DEVELOPMENT.md
+    about: Installation, CLI commands, the data model, and testing.

--- a/.github/ISSUE_TEMPLATE/suggest-org.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-org.yml
@@ -1,0 +1,66 @@
+name: Suggest an organization
+description: Propose a Swiss public-sector GitHub org to add to the inventory.
+title: "[suggestion]: <organization name>"
+labels: ["suggestion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping grow the inventory! A maintainer reviews every
+        suggestion and curates `data/orgs/` by hand — nothing is added
+        automatically. Two scope rules keep the list focused (see
+        [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md)):
+        **GitHub only** (GitLab / Bitbucket are out of scope) and
+        **federal or cantonal** authorities only (municipal is out of scope).
+  - type: input
+    id: name
+    attributes:
+      label: Display name
+      description: The service (federal) or unit (cantonal) name to show in the list.
+      placeholder: Federal Office of Topography
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: GitHub organization URL
+      placeholder: https://github.com/swisstopo
+    validations:
+      required: true
+  - type: dropdown
+    id: authority
+    attributes:
+      label: Authority level
+      options:
+        - Federal
+        - Cantonal
+        - Not sure
+    validations:
+      required: true
+  - type: input
+    id: canton
+    attributes:
+      label: Canton (if cantonal)
+      description: ISO 3166-2:CH code, e.g. ZH, BE, VD. Leave blank for federal.
+      placeholder: ZH
+  - type: textarea
+    id: provenance
+    attributes:
+      label: Evidence / provenance
+      description: >
+        How do we know this org is official? A registry listing (e.g.
+        swiss/index), a GitHub verified-domain match to an *.admin.ch /
+        *.<canton>.ch domain, or an explicit confirmation. Without evidence the
+        entry is recorded as an unverified candidate.
+      placeholder: Listed in github.com/swiss/index; GitHub-verified swisstopo.admin.ch
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This is a GitHub organization (not GitLab, Bitbucket, or another forge).
+          required: true
+        - label: This is a federal or cantonal authority (not a municipality).
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing & governance
+
+Thanks for helping build the inventory of Swiss public-sector open source. This
+page covers **what** the project accepts and **how** it is governed. For the
+**mechanics** — installing, running the CLI, the data model, harvesting, and
+testing — see [DEVELOPMENT.md](./DEVELOPMENT.md).
+
+## Ways to contribute
+
+- **Suggest an organization** (no GitHub know-how needed). Open a
+  [suggestion issue](../../issues/new/choose) and fill in the form. A maintainer
+  reviews it and curates the data by hand.
+- **Add or edit data directly.** Add a file under `data/orgs/` and regenerate
+  the views — the step-by-step is in
+  [DEVELOPMENT.md](./DEVELOPMENT.md#contributing).
+
+## Scope
+
+Two deliberate boundaries keep the list meaningful (full rationale in
+[SPEC.md](./SPEC.md)):
+
+- **GitHub only.** GitLab (incl. self-hosted / openCoDE), Bitbucket, and other
+  forges are out of scope. Coverage means "present on GitHub", **not**
+  "publishes open source" — so absence is never evidence that an authority
+  publishes nothing.
+- **Federal + cantonal only.** Municipal authorities (~2,000 communes) are out
+  of scope as a coverage goal.
+
+Expanding either boundary is an "ask first" change, not routine work.
+
+## What "official" means (provenance policy)
+
+Every organization carries an `official` flag. It is set to `true` **only** with
+recorded `provenance` — evidence stored alongside the entry. Accepted evidence
+(SPEC decision #5):
+
+- a listing in a recognized registry (e.g. `github.com/swiss/index`);
+- a GitHub **verified-domain** match to an `*.admin.ch` / `*.<canton>.ch`
+  domain; or
+- an explicit confirmation from the authority.
+
+Without such evidence the entry stays `official: false` — an unverified
+candidate. Verified-official orgs are marked with a ✅ in the README tables.
+We never mark an organization official without recorded provenance.
+
+## How curation works
+
+The automated tools are **read-only**: they surface gaps and problems, but a
+human always decides what changes:
+
+- `ingest` reconciles sibling registries (`swiss/index`) against `data/orgs/`
+  and reports orgs that are listed upstream but missing locally.
+- `check` flags link rot — renamed or deleted org URLs.
+- `report` summarizes license coverage, staleness, authority coverage, and
+  EMBAG visibility.
+
+None of them edit `data/orgs/`. Maintainers apply the fixes by hand (with
+provenance), so curation stays human and auditable.
+
+## Pull request expectations
+
+- `ruff check . && ruff format --check .`, `pytest`, and
+  `python -m codeswissgov validate` must all pass (CI enforces them).
+- Regenerate the views (`python -m codeswissgov build`) and commit the updated
+  `README.md` / `inventory.json` alongside any `data/orgs/` change — never edit
+  the generated rows by hand.
+
+## Code of conduct
+
+Be respectful and constructive. This is a public-sector transparency project;
+keep discussion focused on the data and the tooling.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -227,6 +227,23 @@ run they degrade to a "run harvest" note while authority coverage still works
 from `data/orgs`. The report functions are pure (`render/reports.py`); file I/O
 is in `build.run_report`.
 
+## Governance & community
+
+Community-facing process lives in [CONTRIBUTING.md](./CONTRIBUTING.md) (scope,
+the "official" provenance policy, and how read-only tools surface gaps for human
+curation). The mechanics:
+
+- **Verified-official badge.** `render/readme.py` appends ` ✅` (`OFFICIAL_BADGE`)
+  to a table row when `org.official` is true. With every org currently
+  `official: false` the rendered README is byte-identical, so `validate` stays
+  green — the badge is dormant until provenance is curated.
+- **Suggestion template.** `.github/ISSUE_TEMPLATE/suggest-org.yml` is a GitHub
+  issue-form capturing name, org URL, authority, canton, and provenance;
+  `config.yml` disables blank issues and links to the guides.
+
+Setting `official: true` requires recorded `provenance` (the model enforces it);
+populating it across `data/orgs` is human curation, not an automated step.
+
 ## Testing & linting
 
 ```sh

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ gate) fails if the committed views are out of date.
 
 ```
 src/codeswissgov/
-  __main__.py        → CLI dispatch (build | validate | harvest | ingest | check)
+  __main__.py        → CLI dispatch (build | validate | harvest | ingest | check | report)
   models.py          → pydantic models: Organization, Repository
   loader.py          → load + validate data/orgs/*.yaml
   build.py           → render_all / build / validate
@@ -39,6 +39,7 @@ src/codeswissgov/
     __init__.py      → deterministic ordering (federal / cantonal)
     readme.py        → data/orgs → README tables (between markers)
     inventory.py     → data/orgs (+ harvest) → inventory.json
+    reports.py       → license / staleness / coverage / EMBAG reports (pure)
   harvest/
     __init__.py      → run_harvest orchestration
     github.py        → GitHub GraphQL client
@@ -82,6 +83,7 @@ All commands run as `python -m codeswissgov <command>`.
 | `harvest` | Enrich `inventory.json` with repo-level data from the GitHub API. |
 | `ingest` | Reconcile sibling registries (`swiss/index`) against `data/orgs/`; print a read-only report. |
 | `check` | Detect link rot in the curated org URLs (404 / renamed); print a read-only report. |
+| `report` | Print license / staleness / authority-coverage / EMBAG reports from `data/orgs` + `inventory.json`. |
 
 ```sh
 python -m codeswissgov build
@@ -89,6 +91,7 @@ python -m codeswissgov validate
 python -m codeswissgov harvest --token "$GITHUB_TOKEN"   # or $GITHUB_TOKEN in env
 python -m codeswissgov ingest                            # no token needed
 python -m codeswissgov check                             # no token needed
+python -m codeswissgov report                            # no token needed
 ```
 
 ## Contributing
@@ -197,6 +200,32 @@ orgs and the action to take, but never edits `data/orgs` — a maintainer makes
 the change by hand. Classification and rendering are pure
 (`check/linkrot.py`); the single HTTP call is isolated in `check/__init__.py`
 (`fetch_status`), so tests run offline.
+
+## Reports (report)
+
+`report` answers the OSPO questions from the data already on disk — no network,
+no token:
+
+```sh
+python -m codeswissgov report
+```
+
+It renders four read-only sections:
+
+- **Authority coverage** — federal org count and which cantons have a known
+  GitHub org vs. publish nothing. Always printed with the **GitHub-only
+  caveat**: absence means "no GitHub org found", not "publishes no open source".
+- **License coverage** — share of harvested repos carrying a license; repos with
+  no license are counted as compliance flags.
+- **Staleness** — archived, stale (no push in ~2 years, `STALE_AFTER_DAYS`), and
+  never-active repos (overlapping lenses).
+- **EMBAG visibility (federal)** — the license/visibility slice over federal
+  orgs only, since EMBAG ("public money → public code") binds federal bodies.
+
+The repo-level sections need a populated `inventory.json`; until `harvest` has
+run they degrade to a "run harvest" note while authority coverage still works
+from `data/orgs`. The report functions are pure (`render/reports.py`); file I/O
+is in `build.run_report`.
 
 ## Testing & linting
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -29,7 +29,7 @@ gate) fails if the committed views are out of date.
 
 ```
 src/codeswissgov/
-  __main__.py        → CLI dispatch (build | validate | harvest | ingest)
+  __main__.py        → CLI dispatch (build | validate | harvest | ingest | check)
   models.py          → pydantic models: Organization, Repository
   loader.py          → load + validate data/orgs/*.yaml
   build.py           → render_all / build / validate
@@ -46,6 +46,9 @@ src/codeswissgov/
     __init__.py      → run_ingest orchestration
     registry.py      → Candidate model, RegistrySource, reconcile, render_report
     swiss_index.py   → swiss/index registry source
+  check/
+    __init__.py      → run_check orchestration + fetch_status (HTTP)
+    linkrot.py       → classify + build_report + render_report (pure)
 data/orgs/*.yaml     → SOURCE OF TRUTH (curated, git-tracked)
 tests/               → pytest unit + fixture-based tests
   fixtures/          → recorded API / registry responses
@@ -78,12 +81,14 @@ All commands run as `python -m codeswissgov <command>`.
 | `validate` | Schema-check `data/orgs/` **and** assert the generated views are up to date (the CI gate). |
 | `harvest` | Enrich `inventory.json` with repo-level data from the GitHub API. |
 | `ingest` | Reconcile sibling registries (`swiss/index`) against `data/orgs/`; print a read-only report. |
+| `check` | Detect link rot in the curated org URLs (404 / renamed); print a read-only report. |
 
 ```sh
 python -m codeswissgov build
 python -m codeswissgov validate
 python -m codeswissgov harvest --token "$GITHUB_TOKEN"   # or $GITHUB_TOKEN in env
 python -m codeswissgov ingest                            # no token needed
+python -m codeswissgov check                             # no token needed
 ```
 
 ## Contributing
@@ -168,6 +173,30 @@ The report lists orgs present in a registry but **missing** from `data/orgs/`
 section. It is guidance only: a maintainer decides what to add and creates the
 YAML file by hand (with provenance), so curation stays human. Non-GitHub forges
 (e.g. GitLab entries in `swiss/index`) are reported as skipped.
+
+## Link-rot detection (check)
+
+Curated org URLs go stale when an organization is renamed or deleted on GitHub.
+`check` requests each `github.com/<login>` page (tokenless, redirects
+**unfollowed**) and reads only the status and any `Location` header:
+
+```sh
+python -m codeswissgov check        # no token needed (public pages)
+```
+
+- `200` → **alive**.
+- `301`/`302` to a *different* login → **renamed** (the report shows the new
+  URL). A redirect to the *same* login — GitHub normalizing case or a trailing
+  slash — is treated as alive, not a false rename.
+- `404` → **gone**.
+- a transport failure → **could not be checked** (one flaky URL never aborts the
+  run).
+
+Like `ingest`, the report is **read-only guidance**: it names the renamed/gone
+orgs and the action to take, but never edits `data/orgs` — a maintainer makes
+the change by hand. Classification and rendering are pure
+(`check/linkrot.py`); the single HTTP call is isolated in `check/__init__.py`
+(`fetch_status`), so tests run offline.
 
 ## Testing & linting
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,20 @@ truth) — don't edit the rows by hand. Coverage is **GitHub only**: authorities
 that publish solely off GitHub do not appear here, so absence is not evidence
 that an authority publishes nothing.
 
+A ✅ next to an entry marks a **verified-official** organization (backed by
+recorded provenance). Entries without it are unverified candidates — see the
+provenance policy in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 ## Contributing & development
 
-To add or update an organization, edit `data/orgs/` and regenerate the views.
-Full instructions — installation, commands, the data model, harvesting, and
-testing — are in **[DEVELOPMENT.md](./DEVELOPMENT.md)**.
+Spotted a missing authority? Open a **[suggestion
+issue](../../issues/new/choose)** — no GitHub know-how needed. How suggestions
+are reviewed, what makes an org "official", and the project's governance are in
+**[CONTRIBUTING.md](./CONTRIBUTING.md)**.
+
+To add or update an organization yourself, edit `data/orgs/` and regenerate the
+views. Full instructions — installation, commands, the data model, harvesting,
+and testing — are in **[DEVELOPMENT.md](./DEVELOPMENT.md)**.
 
 See also [`SPEC.md`](./SPEC.md) (the buildable contract) and
 [`DESIGN.md`](./DESIGN.md) (strategy and rationale).

--- a/SPEC.md
+++ b/SPEC.md
@@ -271,9 +271,14 @@ Fold in the audit backlog so the tool is solid before the refactor.
       no consumer needs the others yet. The pluggable `RegistrySource` framework
       (Epic 3) is the seam they slot into later.
 
-### Epic 6 — Governance & community
-- [ ] Verified-official provenance/badge; suggestion issue templates;
-      contribution governance documented.
+### Epic 6 — Governance & community (mechanics only — see decision #13)
+- [x] Verified-official **badge** (✅) rendered for `official: true` orgs in the
+      README tables; **suggestion issue template**
+      (`.github/ISSUE_TEMPLATE/suggest-org.yml`); contribution **governance**
+      documented (`CONTRIBUTING.md`: scope, provenance policy, read-only-tools
+      curation). Populating `official`/`provenance` across `data/orgs` is left
+      to human curation — a bulk data change is "ask first" (decision #13), so
+      the badge is dormant until an org is verified.
 
 ---
 
@@ -355,6 +360,17 @@ Fold in the audit backlog so the tool is solid before the refactor.
     consumer yet. They slot into the pluggable `RegistrySource` framework when a
     real need appears. Re-expanding Epic 5 is a normal backlog decision, not an
     "ask-first" scope change.
+13. **Epic 6 → governance mechanics only; provenance population stays human.**
+    The mechanics ship: a ✅ verified-official badge in the README renderer (for
+    `official: true` rows), a `suggest-org` issue-form template
+    (`blank_issues_enabled: false`, with contact links to the guides), and
+    `CONTRIBUTING.md` documenting scope, the provenance policy (decision #5),
+    and the "tools surface gaps; humans curate" philosophy. **Populating**
+    `official`/`provenance` is deliberately *not* part of this epic: setting
+    orgs official in bulk (e.g. from a `swiss/index` listing) is a data change,
+    and bulk data changes / marking orgs official are "ask-first" boundaries.
+    The badge therefore renders nothing until a maintainer curates provenance —
+    intended, not a gap. No committed view changes, so `validate` stays green.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -69,7 +69,8 @@ Coverage:  pytest --cov=codeswissgov --cov-report=term-missing
 Build:     python -m codeswissgov build        # regenerate README.md + inventory.json from data/
 Validate:  python -m codeswissgov validate     # schema-check data/ AND assert build is up to date
 Harvest:   python -m codeswissgov harvest --token $GITHUB_TOKEN   # enrich data/ from the GitHub API
-Discover:  python -m codeswissgov discover --token $GITHUB_TOKEN  # propose new orgs/repos (writes suggestions, never auto-adds)
+Ingest:    python -m codeswissgov ingest                          # reconcile sibling registries vs data/orgs (read-only report)
+Check:     python -m codeswissgov check                           # detect link rot in curated org URLs (read-only report)
 ```
 
 ---
@@ -246,8 +247,15 @@ Fold in the audit backlog so the tool is solid before the refactor.
       — **deferred** (decision #10): speculative until a consumer exists.
 
 ### Epic 4 — Data integrity
-- [ ] Link-rot detection flags 404 / renamed / deleted orgs.
-- [ ] Archived/transferred repos detected and reflected in the inventory.
+- [x] Link-rot detection flags 404 / renamed / deleted orgs. `python -m
+      codeswissgov check` requests each curated `github.com/<login>` page
+      (tokenless, redirects unfollowed) and classifies it alive / renamed (301
+      to a different login) / gone (404), printing a **read-only** report — it
+      never edits `data/orgs` (decision #11).
+- [x] Archived repos detected and reflected in the inventory — harvested as
+      `Repository.archived` (Epic 2) and surfaced in the Epic 5 reports.
+      ~~transferred~~ repo redirect detection **deferred** as YAGNI (decision
+      #11): expensive per-repo redirect chasing with no current consumer.
 
 ### Epic 5 — Discovery & reporting
 - [ ] Discovery vectors (org expansion, heuristic search, domain `code.json`
@@ -313,6 +321,19 @@ Fold in the audit backlog so the tool is solid before the refactor.
     stays pluggable so each slots in when a real need appears (e.g. a Swiss
     second source like opendata.swiss). Re-expanding Epic 3 is a normal
     backlog decision, not an "ask-first" scope change.
+11. **Epic 4 link-rot → tokenless read-only `check`; transferred-repo detection
+    deferred.** Link rot is checked by requesting the public
+    `github.com/<login>` page with redirects unfollowed and reading only the
+    status (+ `Location`): 200 = alive, a 301/302 to a *different* login
+    (compared via `login_key`, so a slash/case redirect to the *same* login is
+    not a false rename) = renamed, 404 = gone. It is **read-only** — like
+    `ingest`, it prints a report for a human to curate and never edits
+    `data/orgs` (consistent with the "never auto-add" / "ask-first on data
+    changes" boundaries). No token: the web page needs no auth, so the check can
+    run anywhere without a secret. The archived half of the second criterion is
+    already met by Epic 2's harvest (`Repository.archived`) and surfaced in the
+    Epic 5 reports; **transferred-repo** redirect detection is **deferred** as
+    YAGNI (chasing per-repo redirects is expensive and has no current consumer).
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,6 +71,7 @@ Validate:  python -m codeswissgov validate     # schema-check data/ AND assert b
 Harvest:   python -m codeswissgov harvest --token $GITHUB_TOKEN   # enrich data/ from the GitHub API
 Ingest:    python -m codeswissgov ingest                          # reconcile sibling registries vs data/orgs (read-only report)
 Check:     python -m codeswissgov check                           # detect link rot in curated org URLs (read-only report)
+Report:    python -m codeswissgov report                          # license / staleness / coverage / EMBAG reports (read-only)
 ```
 
 ---
@@ -257,11 +258,18 @@ Fold in the audit backlog so the tool is solid before the refactor.
       ~~transferred~~ repo redirect detection **deferred** as YAGNI (decision
       #11): expensive per-repo redirect chasing with no current consumer.
 
-### Epic 5 — Discovery & reporting
-- [ ] Discovery vectors (org expansion, heuristic search, domain `code.json`
-      probe) produce *suggestions* (never auto-adds).
-- [ ] Reports: license coverage %, stale/archived counts, **authority coverage**
-      ("who publishes nothing"), and an **EMBAG-visibility** view.
+### Epic 5 — Discovery & reporting (trimmed — see decision #12)
+- [x] Reports: license coverage %, stale/archived counts, **authority coverage**
+      ("who publishes nothing", with the GitHub-only caveat printed inline), and
+      an **EMBAG-visibility** (federal) view. `python -m codeswissgov report`
+      renders them from `data/orgs` + `inventory.json`, pure and offline;
+      repo-level sections degrade to "run harvest" until the inventory is
+      populated.
+- [ ] ~~Discovery vectors (org expansion, heuristic search, domain `code.json`
+      probe)~~ — **deferred** (decision #12): `ingest` already discovers via
+      registry, heuristic search would surface out-of-scope municipal noise, and
+      no consumer needs the others yet. The pluggable `RegistrySource` framework
+      (Epic 3) is the seam they slot into later.
 
 ### Epic 6 — Governance & community
 - [ ] Verified-official provenance/badge; suggestion issue templates;
@@ -334,6 +342,19 @@ Fold in the audit backlog so the tool is solid before the refactor.
     already met by Epic 2's harvest (`Repository.archived`) and surfaced in the
     Epic 5 reports; **transferred-repo** redirect detection is **deferred** as
     YAGNI (chasing per-repo redirects is expensive and has no current consumer).
+12. **Epic 5 trimmed to reports; discovery vectors deferred as YAGNI.** The
+    reporting half is load-bearing and shipped (`report`): license coverage %,
+    stale/archived counts, authority coverage ("who publishes nothing", stated
+    with the GitHub-only caveat so the under-count is not misread), and an
+    EMBAG-visibility federal slice — all pure functions over `data/orgs` +
+    `inventory.json`, rendered read-only. The **discovery vectors** (org-member
+    expansion, heuristic search, domain `code.json` probe) are **deferred**:
+    `ingest` already performs registry-based discovery (suggestions, never
+    auto-add); heuristic search (`kanton-*`, `stadt-*`) would surface
+    **municipal** results that are an explicit non-goal; and the others have no
+    consumer yet. They slot into the pluggable `RegistrySource` framework when a
+    real need appears. Re-expanding Epic 5 is a normal backlog decision, not an
+    "ask-first" scope change.
 
 ---
 

--- a/src/codeswissgov/__main__.py
+++ b/src/codeswissgov/__main__.py
@@ -12,23 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""CLI entry point: ``python -m codeswissgov <build|validate|harvest|ingest>``.
+"""CLI entry point: ``python -m codeswissgov <build|validate|harvest|ingest|check>``.
 
 ``build``    regenerate README.md + inventory.json from data/orgs.
 ``validate`` schema-check data/orgs and assert the generated views are current.
 ``harvest``  enrich inventory.json with repo-level data from the GitHub API.
 ``ingest``   reconcile sibling registries (swiss/index) against data/orgs.
+``check``    detect link rot in the curated org URLs (read-only report).
 """
 
 import os
 import sys
 
 from .build import build, validate
+from .check import run_check
+from .check.linkrot import render_report as render_linkrot_report
 from .harvest import run_harvest
 from .ingest import run_ingest
 from .ingest.registry import IngestError, render_report
 
-USAGE = "usage: python -m codeswissgov <build|validate|harvest [--token TOKEN]|ingest>"
+USAGE = (
+    "usage: python -m codeswissgov "
+    "<build|validate|harvest [--token TOKEN]|ingest|check>"
+)
 
 
 def _cmd_build(args: list[str]) -> int:
@@ -93,6 +99,17 @@ def _cmd_ingest(args: list[str]) -> int:
     return 0
 
 
+def _cmd_check(args: list[str]) -> int:
+    """Check the curated org URLs for link rot and print a read-only report.
+
+    Tokenless (public github.com pages) and never mutates data/orgs — it only
+    surfaces renamed/deleted orgs for a human to curate.
+    """
+    report = run_check()
+    print(render_linkrot_report(report), end="")
+    return 0
+
+
 def _token(args: list[str]) -> str | None:
     """Resolve a token from ``--token VALUE``/``--token=VALUE`` or env."""
     for i, arg in enumerate(args):
@@ -108,6 +125,7 @@ COMMANDS = {
     "validate": _cmd_validate,
     "harvest": _cmd_harvest,
     "ingest": _cmd_ingest,
+    "check": _cmd_check,
 }
 
 

--- a/src/codeswissgov/__main__.py
+++ b/src/codeswissgov/__main__.py
@@ -19,12 +19,13 @@
 ``harvest``  enrich inventory.json with repo-level data from the GitHub API.
 ``ingest``   reconcile sibling registries (swiss/index) against data/orgs.
 ``check``    detect link rot in the curated org URLs (read-only report).
+``report``   print license / staleness / coverage / EMBAG reports (read-only).
 """
 
 import os
 import sys
 
-from .build import build, validate
+from .build import build, run_report, validate
 from .check import run_check
 from .check.linkrot import render_report as render_linkrot_report
 from .harvest import run_harvest
@@ -33,7 +34,7 @@ from .ingest.registry import IngestError, render_report
 
 USAGE = (
     "usage: python -m codeswissgov "
-    "<build|validate|harvest [--token TOKEN]|ingest|check>"
+    "<build|validate|harvest [--token TOKEN]|ingest|check|report>"
 )
 
 
@@ -110,6 +111,12 @@ def _cmd_check(args: list[str]) -> int:
     return 0
 
 
+def _cmd_report(args: list[str]) -> int:
+    """Print the read-only inventory reports (license / staleness / coverage)."""
+    print(run_report(), end="")
+    return 0
+
+
 def _token(args: list[str]) -> str | None:
     """Resolve a token from ``--token VALUE``/``--token=VALUE`` or env."""
     for i, arg in enumerate(args):
@@ -126,6 +133,7 @@ COMMANDS = {
     "harvest": _cmd_harvest,
     "ingest": _cmd_ingest,
     "check": _cmd_check,
+    "report": _cmd_report,
 }
 
 

--- a/src/codeswissgov/build.py
+++ b/src/codeswissgov/build.py
@@ -18,11 +18,13 @@ Shared by the ``build`` and ``validate`` CLI commands (T5).
 """
 
 from dataclasses import dataclass
+from datetime import date
 from pathlib import Path
 
 from .loader import load_organizations
 from .render.inventory import load_harvest, render_inventory
 from .render.readme import render_readme
+from .render.reports import render_reports
 
 # Repo root: src/codeswissgov/build.py -> parents[2].
 DEFAULT_ROOT = Path(__file__).resolve().parents[2]
@@ -65,6 +67,25 @@ def build(root: Path = DEFAULT_ROOT) -> RenderResult:
     result.readme_path.write_text(result.readme_text, encoding="utf-8")
     result.inventory_path.write_text(result.inventory_text, encoding="utf-8")
     return result
+
+
+def run_report(root: Path = DEFAULT_ROOT, *, today: date | None = None) -> str:
+    """Render the read-only inventory reports from data/orgs + inventory.json.
+
+    Reuses the build helpers (``load_organizations``, ``load_harvest``) to read
+    the curated orgs and the harvested repos, then delegates to the pure
+    :func:`codeswissgov.render.reports.render_reports`. No network, no writes.
+
+    Args:
+        root: Repository root containing ``data/orgs`` and ``inventory.json``.
+        today: Reference date for staleness; defaults to the current date.
+    """
+    orgs = load_organizations(root / "data" / "orgs")
+    inventory_path = root / "inventory.json"
+    harvest = load_harvest(
+        inventory_path.read_text(encoding="utf-8") if inventory_path.exists() else ""
+    )
+    return render_reports(orgs, harvest, today=today or date.today())
 
 
 def validate(root: Path = DEFAULT_ROOT) -> list[str]:

--- a/src/codeswissgov/check/__init__.py
+++ b/src/codeswissgov/check/__init__.py
@@ -1,0 +1,87 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Link-rot detection: check every curated org URL, never edit ``data/orgs``.
+
+The curated org URLs in ``data/orgs`` go stale when an organization is renamed
+or deleted on GitHub. This package checks each one and emits a **read-only**
+report (parallel to ``ingest``) so a human can curate the fix. The check is
+**tokenless**: it requests the public ``github.com/<login>`` page and reads only
+the HTTP status and any redirect target — no API, no auth. Network I/O is
+isolated in :func:`fetch_status`; classification and rendering are pure
+(:mod:`codeswissgov.check.linkrot`), so tests run offline.
+"""
+
+from pathlib import Path
+
+import httpx
+
+from ..build import DEFAULT_ROOT
+from ..loader import load_organizations
+from .linkrot import ERROR, LinkResult, LinkRotReport, build_report, classify
+
+__all__ = ["fetch_status", "run_check"]
+
+
+def fetch_status(client: httpx.Client, url: str) -> tuple[int, str | None]:
+    """Return ``(status_code, location)`` for ``url`` without following redirects.
+
+    A 404 or a redirect is a meaningful link-rot signal, not an error, so the
+    status is returned verbatim. ``location`` is the redirect target header, or
+    ``None`` when absent.
+
+    Raises:
+        httpx.HTTPError: a transport-level failure (caught by :func:`run_check`).
+    """
+    response = client.get(
+        url,
+        follow_redirects=False,
+        headers={"User-Agent": "awesome-codeswissgov-check"},
+    )
+    return response.status_code, response.headers.get("location")
+
+
+def run_check(
+    root: Path = DEFAULT_ROOT,
+    *,
+    client: httpx.Client | None = None,
+) -> LinkRotReport:
+    """Check every curated org URL and return a read-only :class:`LinkRotReport`.
+
+    Args:
+        root: Repository root containing ``data/orgs``.
+        client: Injected ``httpx.Client`` (tests); a default one is created and
+            closed here when omitted (same pattern as ``run_ingest``).
+
+    A transport failure on one org becomes an ``ERROR`` result rather than
+    aborting the run, so one flaky URL never hides the rest. Nothing is written.
+    """
+    orgs = load_organizations(root / "data" / "orgs")
+
+    owns_client = client is None
+    client = client or httpx.Client(timeout=30.0)
+    results: list[LinkResult] = []
+    try:
+        for org in orgs:
+            try:
+                status, location = fetch_status(client, org.url)
+            except httpx.HTTPError as exc:
+                results.append(LinkResult(org, ERROR, str(exc)))
+                continue
+            results.append(classify(org, status, location))
+    finally:
+        if owns_client:
+            client.close()
+
+    return build_report(results)

--- a/src/codeswissgov/check/linkrot.py
+++ b/src/codeswissgov/check/linkrot.py
@@ -1,0 +1,151 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure link-rot classification and report rendering.
+
+An org URL in ``data/orgs`` can rot three ways: the org is **renamed** (GitHub
+301-redirects the old login to a new one), **deleted** (404), or temporarily
+uncheckable (network error). :func:`classify` turns one HTTP outcome into a
+:class:`LinkResult`; :func:`render_report` renders the aggregate as read-only
+guidance. Nothing here touches the network or the filesystem, so it is fully
+unit-testable offline (the HTTP fetch lives in :mod:`codeswissgov.check`).
+"""
+
+from dataclasses import dataclass
+
+from ..models import Organization
+from ..orgurl import login_key
+
+# Outcome states for a single org URL.
+ALIVE = "alive"
+RENAMED = "renamed"
+GONE = "gone"
+ERROR = "error"
+
+# GitHub answers an org rename with a permanent redirect; cover the temporary
+# ones too so a transient redirect is not misread as a 404.
+_REDIRECTS = frozenset({301, 302, 307, 308})
+
+
+@dataclass(frozen=True)
+class LinkResult:
+    """The outcome of checking one organization's URL.
+
+    Attributes:
+        org: The curated organization that was checked.
+        state: One of :data:`ALIVE`, :data:`RENAMED`, :data:`GONE`, :data:`ERROR`.
+        detail: The new URL for a rename, or a message for an error; ``None``
+            when the state needs no elaboration.
+    """
+
+    org: Organization
+    state: str
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class LinkRotReport:
+    """The aggregate of one ``check`` run, grouped by outcome."""
+
+    alive: list[LinkResult]
+    renamed: list[LinkResult]
+    gone: list[LinkResult]
+    errors: list[LinkResult]
+
+    @property
+    def checked(self) -> int:
+        """Total number of org URLs checked."""
+        return len(self.alive) + len(self.renamed) + len(self.gone) + len(self.errors)
+
+
+def classify(org: Organization, status: int, location: str | None) -> LinkResult:
+    """Classify one HTTP outcome for ``org.url`` into a :class:`LinkResult`.
+
+    Args:
+        org: The organization whose URL was requested.
+        status: The HTTP status code (redirects are *not* followed).
+        location: The ``Location`` header on a redirect, else ``None``.
+
+    A redirect to the *same* login (GitHub normalizing case or a trailing slash)
+    is :data:`ALIVE`, not a rename — compared via :func:`login_key`.
+    """
+    if status == 200:
+        return LinkResult(org, ALIVE)
+    if status in _REDIRECTS:
+        if location is None:
+            return LinkResult(org, ERROR, f"redirect ({status}) without Location")
+        if login_key(location) == login_key(org.url):
+            return LinkResult(org, ALIVE)  # slash/case normalization, same org
+        return LinkResult(org, RENAMED, location)
+    if status == 404:
+        return LinkResult(org, GONE)
+    return LinkResult(org, ERROR, f"unexpected status {status}")
+
+
+def build_report(results: list[LinkResult]) -> LinkRotReport:
+    """Group flat :class:`LinkResult` records by their state."""
+    buckets: dict[str, list[LinkResult]] = {
+        ALIVE: [],
+        RENAMED: [],
+        GONE: [],
+        ERROR: [],
+    }
+    for result in results:
+        buckets[result.state].append(result)
+    return LinkRotReport(
+        alive=buckets[ALIVE],
+        renamed=buckets[RENAMED],
+        gone=buckets[GONE],
+        errors=buckets[ERROR],
+    )
+
+
+def render_report(report: LinkRotReport) -> str:
+    """Render a link-rot report as read-only markdown guidance.
+
+    The renamed/gone/error sections name the org and the action a curator should
+    take in ``data/orgs`` — the tool never edits it.
+    """
+    lines = [
+        "# Link-rot report",
+        "",
+        f"Checked {report.checked} org URL(s) against github.com "
+        "(read-only; data/orgs is never edited).",
+        "",
+        f"- {len(report.alive)} alive",
+        f"- {len(report.renamed)} renamed (org moved — update the url in data/orgs)",
+        f"- {len(report.gone)} gone (404 — remove or replace in data/orgs)",
+        f"- {len(report.errors)} could not be checked",
+        "",
+        "## Renamed (update the url in data/orgs)",
+        "",
+    ]
+    lines += _section(
+        report.renamed, lambda r: f"{r.org.name}: {r.org.url} → {r.detail}"
+    )
+    lines += ["", "## Gone — 404 (review and curate)", ""]
+    lines += _section(report.gone, lambda r: f"{r.org.name}: {r.org.url}")
+    if report.errors:
+        lines += ["", "## Could not be checked", ""]
+        lines += _section(
+            report.errors, lambda r: f"{r.org.name}: {r.org.url} ({r.detail})"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _section(results, fmt) -> list[str]:
+    """Render one report section's bullet lines, or a ``(none)`` placeholder."""
+    if not results:
+        return ["- (none)"]
+    return [f"- {fmt(r)}" for r in results]

--- a/src/codeswissgov/render/readme.py
+++ b/src/codeswissgov/render/readme.py
@@ -28,6 +28,16 @@ FEDERAL_HEADER = "|Service|Link|\n|-------|----|\n"
 CANTONAL_HEADER = "|Canton|Link|\n|------|----|\n"
 # Rendered for a canton with no known GitHub org (derived, not stored).
 NONE_KNOWN = "— none known yet"
+# Appended to a row whose org is verified-official (SPEC decision #5). Dormant
+# until provenance is curated: with every org `official: false` today, no row
+# changes, so `validate` stays green.
+OFFICIAL_BADGE = " ✅"
+
+
+def _badge(org: Organization) -> str:
+    """Return the official badge for ``org``, or an empty string."""
+    return OFFICIAL_BADGE if org.official else ""
+
 
 FEDERAL_BEGIN = "<!-- BEGIN FEDERAL LIST -->"
 FEDERAL_END = "<!-- END FEDERAL LIST -->"
@@ -36,7 +46,9 @@ CANTONAL_END = "<!-- END CANTONAL LIST -->"
 
 
 def _federal_block(orgs: list[Organization]) -> str:
-    rows = "".join(f"{o.name}|[Link]({o.url})\n" for o in federal_sorted(orgs))
+    rows = "".join(
+        f"{o.name}|[Link]({o.url}){_badge(o)}\n" for o in federal_sorted(orgs)
+    )
     return f"\n{FEDERAL_HEADER}{rows}\n"
 
 
@@ -50,7 +62,7 @@ def _cantonal_block(orgs: list[Organization]) -> str:
         if not units:
             rows.append(f"{display}|{NONE_KNOWN}\n")
         else:
-            rows.extend(f"{display}|[{o.name}]({o.url})\n" for o in units)
+            rows.extend(f"{display}|[{o.name}]({o.url}){_badge(o)}\n" for o in units)
     return f"\n{CANTONAL_HEADER}{''.join(rows)}\n"
 
 

--- a/src/codeswissgov/render/reports.py
+++ b/src/codeswissgov/render/reports.py
@@ -1,0 +1,212 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure inventory reports: license, staleness, authority coverage, EMBAG.
+
+These turn the curated ``data/orgs`` and the harvested ``inventory.json`` into
+the questions an OSPO actually asks — what share of repos carry a license, how
+many are stale or archived, which authorities publish nothing, and how the
+*federal* picture looks under EMBAG. Everything here is a pure function of its
+inputs (orgs, harvest mapping, a reference ``today``), so it is deterministic
+and offline-testable; file I/O lives in :func:`codeswissgov.build.run_report`.
+"""
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from ..cantons import CANTONS, canton_display
+from ..models import Organization, Repository
+from .inventory import OrgHarvest
+
+# A repo with no push in this window counts as stale (~2 years). Archived and
+# never-active repos are reported separately, so this measures dormancy only.
+STALE_AFTER_DAYS = 730
+
+
+@dataclass(frozen=True)
+class LicenseReport:
+    """License coverage across a set of repositories."""
+
+    total: int
+    licensed: int
+    unlicensed: int  # compliance flags: a repo with no declared license
+
+    @property
+    def coverage_pct(self) -> float | None:
+        """Percent of repos carrying a license, or ``None`` when there are none."""
+        return None if self.total == 0 else 100 * self.licensed / self.total
+
+
+@dataclass(frozen=True)
+class StalenessReport:
+    """Activity lenses over a set of repositories (the lenses may overlap)."""
+
+    total: int
+    archived: int
+    stale: int  # pushed, but not within STALE_AFTER_DAYS
+    no_activity: int  # no recorded last_activity at all
+
+
+@dataclass(frozen=True)
+class CoverageReport:
+    """Authority coverage — who has a GitHub org and who publishes nothing."""
+
+    federal_orgs: int
+    cantons_present: list[str]  # canton codes with >= 1 org
+    cantons_absent: list[str]  # display names of cantons with no GitHub org
+
+
+@dataclass(frozen=True)
+class EmbagReport:
+    """Federal publishing visibility (EMBAG: public money -> public code)."""
+
+    federal_orgs: int
+    federal_orgs_with_repos: int
+    license: LicenseReport
+
+
+def _all_repos(harvest: dict[str, OrgHarvest]) -> list[Repository]:
+    return [repo for entry in harvest.values() for repo in entry.repositories]
+
+
+def license_report(repos: list[Repository]) -> LicenseReport:
+    """Count license coverage and compliance flags across ``repos``."""
+    licensed = sum(1 for r in repos if r.license is not None)
+    return LicenseReport(
+        total=len(repos), licensed=licensed, unlicensed=len(repos) - licensed
+    )
+
+
+def staleness_report(repos: list[Repository], today: date) -> StalenessReport:
+    """Count archived, stale, and never-active repos relative to ``today``."""
+    cutoff = today - timedelta(days=STALE_AFTER_DAYS)
+    archived = stale = no_activity = 0
+    for repo in repos:
+        if repo.archived:
+            archived += 1
+        if repo.last_activity is None:
+            no_activity += 1
+        elif date.fromisoformat(repo.last_activity) < cutoff:
+            stale += 1
+    return StalenessReport(
+        total=len(repos), archived=archived, stale=stale, no_activity=no_activity
+    )
+
+
+def authority_coverage(orgs: list[Organization]) -> CoverageReport:
+    """Report federal org count and which cantons have / lack a GitHub org."""
+    present = {o.canton_code for o in orgs if not o.is_federal}
+    absent = [canton_display(code) for code in CANTONS if code not in present]
+    return CoverageReport(
+        federal_orgs=sum(1 for o in orgs if o.is_federal),
+        cantons_present=sorted(c for c in present if c is not None),
+        cantons_absent=sorted(absent),
+    )
+
+
+def embag_report(
+    orgs: list[Organization], harvest: dict[str, OrgHarvest]
+) -> EmbagReport:
+    """Federal-only license/visibility slice (EMBAG applies to federal bodies)."""
+    federal_urls = [o.url for o in orgs if o.is_federal]
+    federal_repos: list[Repository] = []
+    orgs_with_repos = 0
+    for url in federal_urls:
+        repos = harvest[url].repositories if url in harvest else []
+        if repos:
+            orgs_with_repos += 1
+        federal_repos.extend(repos)
+    return EmbagReport(
+        federal_orgs=len(federal_urls),
+        federal_orgs_with_repos=orgs_with_repos,
+        license=license_report(federal_repos),
+    )
+
+
+def _pct(report: LicenseReport) -> str:
+    pct = report.coverage_pct
+    return "n/a" if pct is None else f"{pct:.0f}%"
+
+
+def render_reports(
+    orgs: list[Organization],
+    harvest: dict[str, OrgHarvest],
+    *,
+    today: date,
+) -> str:
+    """Render all four reports as a single read-only markdown document."""
+    repos = _all_repos(harvest)
+    coverage = authority_coverage(orgs)
+
+    lines = [
+        "# Inventory report",
+        "",
+        "Read-only. Repo-level figures come from the harvested inventory.json; "
+        "authority coverage comes from data/orgs.",
+        "",
+        "## Authority coverage",
+        "",
+        f"- {coverage.federal_orgs} federal organization(s) tracked.",
+        f"- {len(coverage.cantons_present)}/{len(CANTONS)} cantons have a known "
+        "GitHub org.",
+        f"- {len(coverage.cantons_absent)} canton(s) publish nothing on GitHub "
+        "(that we know of):",
+    ]
+    lines.append(
+        "  " + (", ".join(coverage.cantons_absent) if coverage.cantons_absent else "—")
+    )
+    lines += [
+        "",
+        "> GitHub-only coverage: absence means *no GitHub org found*, **not** "
+        '"publishes no open source" — authorities may publish off GitHub '
+        "(out of scope).",
+        "",
+    ]
+
+    if not repos:
+        lines += [
+            "## Repositories",
+            "",
+            "No harvested repo data yet — run `python -m codeswissgov harvest "
+            "--token $GITHUB_TOKEN` to populate inventory.json.",
+            "",
+        ]
+        return "\n".join(lines) + "\n"
+
+    licenses = license_report(repos)
+    staleness = staleness_report(repos, today)
+    embag = embag_report(orgs, harvest)
+    lines += [
+        "## License coverage",
+        "",
+        f"- {licenses.total} repositories harvested.",
+        f"- {licenses.licensed} licensed ({_pct(licenses)}).",
+        f"- {licenses.unlicensed} without a license (compliance flags).",
+        "",
+        "## Staleness",
+        "",
+        f"- {staleness.archived} archived.",
+        f"- {staleness.stale} stale (no push in {STALE_AFTER_DAYS // 365} years).",
+        f"- {staleness.no_activity} with no recorded activity.",
+        "",
+        "## EMBAG visibility (federal)",
+        "",
+        f"- {embag.federal_orgs_with_repos}/{embag.federal_orgs} federal orgs "
+        "have harvested repositories.",
+        f"- {embag.license.total} federal repositories, "
+        f"{embag.license.licensed} licensed ({_pct(embag.license)}), "
+        f"{embag.license.unlicensed} without a license.",
+        "",
+    ]
+    return "\n".join(lines) + "\n"

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -1,0 +1,160 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for link-rot classification, rendering, and offline orchestration."""
+
+import httpx
+
+from codeswissgov.check import run_check
+from codeswissgov.check.linkrot import (
+    ALIVE,
+    ERROR,
+    GONE,
+    RENAMED,
+    LinkResult,
+    build_report,
+    classify,
+    render_report,
+)
+from codeswissgov.models import Organization
+
+
+def _org(url: str = "https://github.com/admin-ch", name: str = "Org") -> Organization:
+    return Organization(name=name, authority="federal", url=url)
+
+
+# --- classify ---------------------------------------------------------------
+
+
+def test_classify_200_is_alive():
+    result = classify(_org(), 200, None)
+    assert result.state == ALIVE and result.detail is None
+
+
+def test_classify_redirect_to_same_login_is_alive():
+    # Trailing-slash / case normalization redirects to the same org, not a move.
+    org = _org("https://github.com/cdc-si/")
+    result = classify(org, 301, "https://github.com/CDC-SI")
+    assert result.state == ALIVE
+
+
+def test_classify_redirect_to_new_login_is_renamed():
+    org = _org("https://github.com/old-name")
+    result = classify(org, 301, "https://github.com/new-name")
+    assert result.state == RENAMED
+    assert result.detail == "https://github.com/new-name"
+
+
+def test_classify_redirect_without_location_is_error():
+    result = classify(_org(), 302, None)
+    assert result.state == ERROR
+    assert "without Location" in result.detail
+
+
+def test_classify_404_is_gone():
+    assert classify(_org(), 404, None).state == GONE
+
+
+def test_classify_unexpected_status_is_error():
+    result = classify(_org(), 503, None)
+    assert result.state == ERROR
+    assert "503" in result.detail
+
+
+# --- build_report / render_report -------------------------------------------
+
+
+def _results() -> list[LinkResult]:
+    return [
+        LinkResult(_org("https://github.com/a", "Alive Org"), ALIVE),
+        LinkResult(
+            _org("https://github.com/old", "Moved Org"),
+            RENAMED,
+            "https://github.com/new",
+        ),
+        LinkResult(_org("https://github.com/dead", "Dead Org"), GONE),
+        LinkResult(_org("https://github.com/oops", "Flaky Org"), ERROR, "timed out"),
+    ]
+
+
+def test_build_report_groups_by_state():
+    report = build_report(_results())
+    assert report.checked == 4
+    assert [r.org.name for r in report.renamed] == ["Moved Org"]
+    assert [r.org.name for r in report.gone] == ["Dead Org"]
+    assert [r.org.name for r in report.errors] == ["Flaky Org"]
+
+
+def test_render_report_lists_actions_and_counts():
+    text = render_report(build_report(_results()))
+
+    assert text.endswith("\n")
+    assert "Checked 4 org URL(s)" in text
+    assert "data/orgs is never edited" in text
+    assert "- 1 alive" in text
+    assert "Moved Org: https://github.com/old → https://github.com/new" in text
+    assert "Dead Org: https://github.com/dead" in text
+    assert "Flaky Org: https://github.com/oops (timed out)" in text
+
+
+def test_render_report_shows_none_and_omits_error_section_when_clean():
+    text = render_report(build_report([LinkResult(_org(), ALIVE)]))
+    assert "## Renamed" in text and "## Gone" in text
+    assert "- (none)" in text
+    # No errors -> the "could not be checked" section is omitted entirely.
+    assert "## Could not be checked" not in text
+
+
+# --- run_check (offline via pytest-httpx) ------------------------------------
+
+
+def _root(tmp_path, handles):
+    orgs_dir = tmp_path / "data" / "orgs"
+    orgs_dir.mkdir(parents=True)
+    for handle in handles:
+        (orgs_dir / f"{handle}.yaml").write_text(
+            f"name: {handle}\nauthority: federal\nurl: https://github.com/{handle}\n"
+        )
+    return tmp_path
+
+
+def test_run_check_classifies_each_org_offline(tmp_path, httpx_mock):
+    root = _root(tmp_path, ["alive-org", "moved-org", "dead-org"])
+    httpx_mock.add_response(url="https://github.com/alive-org", status_code=200)
+    httpx_mock.add_response(
+        url="https://github.com/moved-org",
+        status_code=301,
+        headers={"Location": "https://github.com/renamed-org"},
+    )
+    httpx_mock.add_response(url="https://github.com/dead-org", status_code=404)
+
+    report = run_check(root, client=httpx.Client())
+
+    assert report.checked == 3
+    assert [r.org.name for r in report.alive] == ["alive-org"]
+    assert [r.detail for r in report.renamed] == ["https://github.com/renamed-org"]
+    assert [r.org.name for r in report.gone] == ["dead-org"]
+
+
+def test_run_check_records_transport_error_without_aborting(tmp_path, httpx_mock):
+    root = _root(tmp_path, ["ok-org", "boom-org"])
+    httpx_mock.add_response(url="https://github.com/ok-org", status_code=200)
+    httpx_mock.add_exception(
+        httpx.ConnectTimeout("slow"), url="https://github.com/boom-org"
+    )
+
+    report = run_check(root, client=httpx.Client())
+
+    assert [r.org.name for r in report.alive] == ["ok-org"]
+    assert [r.org.name for r in report.errors] == ["boom-org"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,3 +205,14 @@ def test_check_prints_report_and_succeeds(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "Link-rot report" in out
     assert "Dead Org: https://github.com/dead" in out
+
+
+# --- report command ---------------------------------------------------------
+
+
+def test_report_prints_inventory_report(capsys):
+    # Runs against the committed data/orgs + inventory.json (offline, no token).
+    assert cli.main(["report"]) == 0
+    out = capsys.readouterr().out
+    assert "# Inventory report" in out
+    assert "## Authority coverage" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -187,3 +187,21 @@ def test_ingest_reports_fetch_error(monkeypatch, capsys):
     monkeypatch.setattr(cli, "run_ingest", boom)
     assert cli.main(["ingest"]) == 1
     assert "failed to fetch" in capsys.readouterr().err
+
+
+# --- check command ----------------------------------------------------------
+
+
+def test_check_prints_report_and_succeeds(monkeypatch, capsys):
+    from codeswissgov.check.linkrot import GONE, LinkResult, build_report
+    from codeswissgov.models import Organization
+
+    org = Organization(
+        name="Dead Org", authority="federal", url="https://github.com/dead"
+    )
+    report = build_report([LinkResult(org, GONE)])
+    monkeypatch.setattr(cli, "run_check", lambda: report)
+    assert cli.main(["check"]) == 0
+    out = capsys.readouterr().out
+    assert "Link-rot report" in out
+    assert "Dead Org: https://github.com/dead" in out

--- a/tests/test_render_readme.py
+++ b/tests/test_render_readme.py
@@ -28,9 +28,9 @@ SKELETON = (
 )
 
 
-def _org(name, authority, handle):
+def _org(name, authority, handle, **kw):
     return Organization(
-        name=name, authority=authority, url=f"https://github.com/{handle}"
+        name=name, authority=authority, url=f"https://github.com/{handle}", **kw
     )
 
 
@@ -48,6 +48,22 @@ def test_canton_with_no_org_renders_none_known():
     out = render_readme([_org("Statistics I", "canton:ZH", "stat")], SKELETON)
     # Jura has no org -> derived placeholder row.
     assert "Jura|— none known yet\n" in out
+
+
+def test_official_org_gets_a_badge_in_both_tables():
+    orgs = [
+        _org("Swiss Admin", "federal", "admin-ch", official=True, provenance="reg"),
+        _org("Stat ZH", "canton:ZH", "stat", official=True, provenance="reg"),
+    ]
+    out = render_readme(orgs, SKELETON)
+    assert "Swiss Admin|[Link](https://github.com/admin-ch) ✅\n" in out
+    assert "Zürich|[Stat ZH](https://github.com/stat) ✅\n" in out
+
+
+def test_unofficial_org_has_no_badge():
+    out = render_readme([_org("Swiss Admin", "federal", "admin-ch")], SKELETON)
+    assert "Swiss Admin|[Link](https://github.com/admin-ch)\n" in out
+    assert "✅" not in out
 
 
 def test_federal_sorted_case_insensitively():

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,186 @@
+# Copyright 2024 ospo.ch authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pure inventory reports and the run_report orchestration."""
+
+import json
+from datetime import date
+
+from codeswissgov.build import run_report
+from codeswissgov.models import Organization, Repository
+from codeswissgov.render.inventory import OrgHarvest
+from codeswissgov.render.reports import (
+    authority_coverage,
+    embag_report,
+    license_report,
+    render_reports,
+    staleness_report,
+)
+
+TODAY = date(2026, 6, 6)  # cutoff for staleness is 2024-06-06 (730 days earlier)
+
+
+def _org(url, authority="federal", name="Org"):
+    return Organization(name=name, authority=authority, url=url)
+
+
+def _repo(name, **kw):
+    return Repository(name=name, url=f"https://github.com/o/{name}", **kw)
+
+
+def _repos():
+    return [
+        _repo("tool", license="MIT", last_activity="2026-01-15"),  # licensed, fresh
+        _repo("legacy", last_activity="2020-01-01", archived=True),  # unlic+stale+arch
+        _repo("lib", license="Apache-2.0", last_activity=None),  # licensed, no activity
+    ]
+
+
+# --- license_report ---------------------------------------------------------
+
+
+def test_license_report_counts_coverage_and_flags():
+    report = license_report(_repos())
+    assert report.total == 3
+    assert report.licensed == 2
+    assert report.unlicensed == 1
+    assert round(report.coverage_pct) == 67
+
+
+def test_license_report_empty_has_no_coverage():
+    report = license_report([])
+    assert report.total == 0 and report.coverage_pct is None
+
+
+# --- staleness_report -------------------------------------------------------
+
+
+def test_staleness_report_lenses():
+    report = staleness_report(_repos(), TODAY)
+    assert report.total == 3
+    assert report.archived == 1  # legacy
+    assert report.stale == 1  # legacy (2020 push < 2024 cutoff)
+    assert report.no_activity == 1  # lib (no last_activity)
+
+
+def test_staleness_boundary_is_exclusive():
+    # A push exactly on the cutoff date is not yet stale (strictly older only).
+    cutoff = "2024-06-06"
+    report = staleness_report([_repo("edge", last_activity=cutoff)], TODAY)
+    assert report.stale == 0
+
+
+# --- authority_coverage -----------------------------------------------------
+
+
+def test_authority_coverage_counts_federal_and_absent_cantons():
+    orgs = [
+        _org("https://github.com/admin-ch"),
+        _org("https://github.com/zh-org", "canton:ZH"),
+    ]
+    report = authority_coverage(orgs)
+    assert report.federal_orgs == 1
+    assert report.cantons_present == ["ZH"]
+    # 25 of 26 cantons publish nothing; Zürich is absent from that list.
+    assert len(report.cantons_absent) == 25
+    assert "Zürich" not in report.cantons_absent
+    assert "Bern" in report.cantons_absent
+
+
+# --- embag_report -----------------------------------------------------------
+
+
+def test_embag_report_is_federal_only():
+    orgs = [
+        _org("https://github.com/fed-a"),
+        _org("https://github.com/fed-b"),  # no repos
+        _org("https://github.com/zh", "canton:ZH"),
+    ]
+    harvest = {
+        "https://github.com/fed-a": OrgHarvest(
+            repositories=[_repo("t", license="MIT"), _repo("u")]
+        ),
+        "https://github.com/zh": OrgHarvest(repositories=[_repo("z", license="GPL")]),
+    }
+    report = embag_report(orgs, harvest)
+    assert report.federal_orgs == 2
+    assert report.federal_orgs_with_repos == 1  # only fed-a
+    # Cantonal repo (z) is excluded from the federal EMBAG slice.
+    assert report.license.total == 2
+    assert report.license.licensed == 1
+
+
+# --- render_reports ---------------------------------------------------------
+
+
+def test_render_reports_full_document():
+    orgs = [_org("https://github.com/o"), _org("https://github.com/zh", "canton:ZH")]
+    harvest = {"https://github.com/o": OrgHarvest(repositories=_repos())}
+    text = render_reports(orgs, harvest, today=TODAY)
+
+    assert text.endswith("\n")
+    assert "## Authority coverage" in text
+    assert "GitHub-only coverage" in text  # the mandated caveat
+    assert "## License coverage" in text
+    assert "3 repositories harvested" in text
+    assert "2 licensed (67%)" in text
+    assert "1 archived" in text
+    assert "## EMBAG visibility (federal)" in text
+
+
+def test_render_reports_handles_empty_harvest():
+    orgs = [_org("https://github.com/o")]
+    text = render_reports(orgs, {}, today=TODAY)
+
+    assert "## Authority coverage" in text  # still works without harvest
+    assert "No harvested repo data yet" in text
+    assert "## License coverage" not in text
+
+
+# --- run_report (end-to-end against a temp repo) ----------------------------
+
+
+def _root(tmp_path, orgs, inventory):
+    orgs_dir = tmp_path / "data" / "orgs"
+    orgs_dir.mkdir(parents=True)
+    for handle, authority in orgs:
+        (orgs_dir / f"{handle}.yaml").write_text(
+            f"name: {handle}\nauthority: {authority}\n"
+            f"url: https://github.com/{handle}\n"
+        )
+    (tmp_path / "inventory.json").write_text(json.dumps(inventory), encoding="utf-8")
+    return tmp_path
+
+
+def test_run_report_reads_orgs_and_inventory(tmp_path):
+    inventory = {
+        "schema_version": "2.0",
+        "organizations": [
+            {
+                "name": "fed-a",
+                "authority": "federal",
+                "url": "https://github.com/fed-a",
+                "official": False,
+                "provenance": None,
+                "harvested_at": "2026-06-01T00:00:00Z",
+                "repositories": [
+                    {"name": "t", "url": "https://github.com/fed-a/t", "license": "MIT"}
+                ],
+            }
+        ],
+    }
+    root = _root(tmp_path, [("fed-a", "federal")], inventory)
+    text = run_report(root, today=TODAY)
+    assert "1 repositories harvested" in text
+    assert "1 licensed (100%)" in text


### PR DESCRIPTION
Completes the remaining roadmap epics ([SPEC.md](./SPEC.md)). Each lands as one self-contained, verified commit; no committed-view or data changes, so the `validate` sync gate stays green throughout. YAGNI-trimmed in line with the Epic 3 precedent — the speculative halves are deferred, not built (decisions #11–#13).

## Data integrity
- `python -m codeswissgov check`: tokenless, read-only link-rot detection. Requests each `github.com/<login>` (redirects unfollowed) and classifies **alive** / **renamed** (301 to a different login) / **gone** (404). A redirect to the *same* login (case/slash normalization) is not a false rename. Prints a report, never edits `data/orgs`.
- Pure classify/render in `check/linkrot.py`; the single HTTP call isolated in `check/__init__.py` so tests run offline.
- Archived repos already covered by Epic 2's harvest; transferred-repo detection deferred as YAGNI (decision #11).

## Discovery & reporting (reports)
- `python -m codeswissgov report`: offline reports over `data/orgs` + `inventory.json` — license coverage % + compliance flags, archived/stale/never-active counts, authority coverage ("who publishes nothing", with the GitHub-only caveat), and a federal EMBAG-visibility slice.
- Pure functions in `render/reports.py` (injected `today` for deterministic staleness); orchestrated by `build.run_report`. Repo-level sections degrade to a "run harvest" note until the inventory is populated.
- Discovery vectors deferred as YAGNI — `ingest` already does registry discovery; heuristic search would surface out-of-scope municipal noise (decision #12).

## Governance & community (mechanics)
- Dormant ✅ verified-official badge in the README renderer (for `official: true` rows), a `suggest-org` GitHub issue form, and `CONTRIBUTING.md` (scope, provenance policy, read-only-tools curation model). README gains a badge legend + suggestion pointer.
- Populating `official`/`provenance` is left to human curation — a bulk data change is ask-first (decision #13). The badge is dormant until an org is verified, so no view churn.

## Verification
- `ruff check . && ruff format --check .` — clean
- `pytest` — 105 passed; 100% coverage on the pure modules (`linkrot`, `reports`, `readme`, `models`), 98% overall
- `python -m codeswissgov validate` — green

SPEC epic checkboxes updated, decisions #11–#13 recorded, and DEVELOPMENT.md documents the new `check`/`report` commands and the governance mechanics.